### PR TITLE
fix(office): handle GBK text and mislabeled DOCX files

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -1,0 +1,636 @@
+# Open File Viewer
+
+<p align="right">
+  <a href="./README.md">Simplified Chinese</a>
+  |
+  <strong>English</strong>
+</p>
+
+Open File Viewer is a file preview SDK for modern web applications. It brings PDFs, Office documents, images, audio and video, archives, emails, drawings, 3D files, GIS data, and source code into one controlled container, with support for vanilla JavaScript, React, Vue, and Svelte.
+
+<p>
+  <a href="https://open-file-viewer-workspace.void.app">Website</a>
+  |
+  <a href="https://open-file-viewer-workspace.void.app/about.html">About</a>
+  |
+  <a href="https://github.com/xushanpei/open-file-viewer">GitHub</a>
+  |
+  <a href="https://www.npmjs.com/package/@open-file-viewer/core">NPM Core</a>
+  |
+  <a href="https://www.npmjs.com/package/@open-file-viewer/react">React</a>
+  |
+  <a href="https://www.npmjs.com/package/@open-file-viewer/vue">Vue</a>
+  |
+  <a href="https://www.npmjs.com/package/@open-file-viewer/svelte">Svelte</a>
+</p>
+
+[![GitHub](https://img.shields.io/badge/GitHub-xushanpei%2Fopen--file--viewer-111827?logo=github)](https://github.com/xushanpei/open-file-viewer)
+[![Core](https://img.shields.io/npm/v/@open-file-viewer/core?label=%40open-file-viewer%2Fcore&color=7c5cff)](https://www.npmjs.com/package/@open-file-viewer/core)
+[![React](https://img.shields.io/npm/v/@open-file-viewer/react?label=react&color=149eca)](https://www.npmjs.com/package/@open-file-viewer/react)
+[![Vue](https://img.shields.io/npm/v/@open-file-viewer/vue?label=vue&color=41b883)](https://www.npmjs.com/package/@open-file-viewer/vue)
+[![Svelte](https://img.shields.io/npm/v/@open-file-viewer/svelte?label=svelte&color=ff3e00)](https://www.npmjs.com/package/@open-file-viewer/svelte)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
+
+## Why Choose It
+
+Most business systems eventually need attachment preview: contracts, spreadsheets, drawings, archives, emails, images, videos, and source files. Open File Viewer is not a PDF-only demo. It is a file preview foundation that can evolve with real product needs over time.
+
+- **Container-first**: all content renders inside the DOM container you provide. It does not open a new window or interrupt the host business page.
+- **Multi-framework compatibility**: vanilla JavaScript, React, Vue, and Svelte share the same core capabilities.
+- **Plugin-based formats**: each file format is handled by an independent plugin, making behavior easier to replace, trim, and extend.
+- **Responsive preview**: supports CSS sizes such as `px`, `%`, `vh`, `vw`, `rem`, and `calc()`, and responds automatically to container changes.
+- **Application-ready states**: includes loading, error, unsupported, download fallback, toolbar, theme, and multi-file queue behavior.
+- **Progressive enhancement for complex formats**: formats that browsers can preview directly are rendered locally first; complex formats can gradually integrate WASM, dedicated parsers, or server-side conversion.
+
+## Installation
+
+```bash
+pnpm add @open-file-viewer/core
+```
+
+React:
+
+```bash
+pnpm add @open-file-viewer/core @open-file-viewer/react
+```
+
+Vue:
+
+```bash
+pnpm add @open-file-viewer/core @open-file-viewer/vue
+```
+
+Svelte:
+
+```bash
+pnpm add @open-file-viewer/core @open-file-viewer/svelte
+```
+
+PDF preview requires `pdfjs-dist` when you use `pdfPlugin()`:
+
+```bash
+pnpm add pdfjs-dist
+```
+
+You can also use npm or yarn:
+
+```bash
+npm install @open-file-viewer/core
+yarn add @open-file-viewer/core
+```
+
+Import the shared stylesheet once in your application:
+
+```ts
+import "@open-file-viewer/core/style.css";
+```
+
+## Quick Start
+
+### Vanilla JavaScript
+
+```ts
+import {
+  createViewer,
+  imagePlugin,
+  videoPlugin,
+  audioPlugin,
+  textPlugin,
+  pdfPlugin,
+  officePlugin,
+  archivePlugin,
+  emailPlugin,
+  drawingPlugin,
+  cadPlugin,
+  model3dPlugin,
+  gisPlugin,
+  fallbackPlugin
+} from "@open-file-viewer/core";
+import "@open-file-viewer/core/style.css";
+import pdfWorkerSrc from "pdfjs-dist/build/pdf.worker.mjs?url";
+
+const viewer = createViewer({
+  container: "#viewer",
+  file: fileOrUrl,
+  fileName: "contract.pdf",
+  width: "100%",
+  height: "70vh",
+  fit: "contain",
+  toolbar: true,
+  theme: "auto",
+  plugins: [
+    imagePlugin(),
+    videoPlugin(),
+    audioPlugin(),
+    textPlugin(),
+    pdfPlugin({ workerSrc: pdfWorkerSrc }),
+    officePlugin(),
+    archivePlugin(),
+    emailPlugin(),
+    drawingPlugin(),
+    cadPlugin(),
+    model3dPlugin(),
+    gisPlugin(),
+    fallbackPlugin()
+  ]
+});
+
+viewer.resize();
+viewer.destroy();
+```
+
+### React
+
+```tsx
+import { FileViewer } from "@open-file-viewer/react";
+import { imagePlugin, pdfPlugin, officePlugin, textPlugin } from "@open-file-viewer/core";
+import "@open-file-viewer/core/style.css";
+import pdfWorkerSrc from "pdfjs-dist/build/pdf.worker.mjs?url";
+
+const plugins = [
+  imagePlugin(),
+  textPlugin(),
+  pdfPlugin({ workerSrc: pdfWorkerSrc }),
+  officePlugin()
+];
+
+export function AttachmentPreview({ file }: { file: File }) {
+  return (
+    <FileViewer
+      file={file}
+      fileName={file.name}
+      width="100%"
+      height="640px"
+      fit="contain"
+      toolbar
+      theme="auto"
+      plugins={plugins}
+    />
+  );
+}
+```
+
+### Vue
+
+```vue
+<script setup lang="ts">
+import { OpenFileViewer } from "@open-file-viewer/vue";
+import { imagePlugin, pdfPlugin, officePlugin, textPlugin } from "@open-file-viewer/core";
+import "@open-file-viewer/core/style.css";
+import pdfWorkerSrc from "pdfjs-dist/build/pdf.worker.mjs?url";
+
+defineProps<{ file: File }>();
+
+const plugins = [
+  imagePlugin(),
+  textPlugin(),
+  pdfPlugin({ workerSrc: pdfWorkerSrc }),
+  officePlugin()
+];
+</script>
+
+<template>
+  <OpenFileViewer
+    :file="file"
+    :file-name="file.name"
+    width="100%"
+    height="640px"
+    fit="contain"
+    toolbar
+    theme="auto"
+    :plugins="plugins"
+  />
+</template>
+```
+
+### Svelte
+
+```svelte
+<script lang="ts">
+  import { OpenFileViewer } from "@open-file-viewer/svelte";
+  import { imagePlugin, pdfPlugin, officePlugin, textPlugin } from "@open-file-viewer/core";
+  import "@open-file-viewer/core/style.css";
+  import pdfWorkerSrc from "pdfjs-dist/build/pdf.worker.mjs?url";
+
+  export let file: File;
+
+  const plugins = [
+    imagePlugin(),
+    textPlugin(),
+    pdfPlugin({ workerSrc: pdfWorkerSrc }),
+    officePlugin()
+  ];
+</script>
+
+<OpenFileViewer
+  {file}
+  fileName={file.name}
+  width="100%"
+  height="640px"
+  fit="contain"
+  toolbar
+  theme="auto"
+  {plugins}
+/>
+```
+
+## Use Cases
+
+| Scenario | What Open File Viewer Provides |
+| --- | --- |
+| OA / ERP / CRM attachment centers | A unified container preview for contracts, spreadsheets, images, emails, and archives |
+| Cloud drives / knowledge bases / document systems | Multi-file queues, download, search, fullscreen, and theme adaptation |
+| Low-code / form systems | Vanilla JS integration without forcing React, Vue, or Svelte |
+| Engineering / manufacturing / GIS systems | Recognition and progressive enhancement for CAD, 3D, GIS, and drawing files |
+| Developer platforms / log platforms | Text, config, Markdown, code highlighting, and large-file protection |
+
+## Feature Overview
+
+| Capability | Status |
+| --- | --- |
+| Vanilla JS / React / Vue / Svelte integration | Supported |
+| Custom container, width, height, and responsive sizing | Supported |
+| Multi-file queue, switching, and current index | Supported |
+| Toolbar, download, fullscreen, print, and search | Supported |
+| Light, dark, and `auto` themes | Supported |
+| Local `File` / `Blob` / URL / `ArrayBuffer` sources | Supported |
+| Plugin protocol and custom fallback | Supported |
+| PDF, images, audio/video, text/code | Supported |
+| Office, OFD, EPUB, XPS, email, and archives | Basic to enhanced preview |
+| CAD, 3D, GIS, drawing boards, and design assets | Detection, basic preview, and ongoing enhancements |
+
+## Format Coverage
+
+| Category | Plugin | Representative Formats |
+| --- | --- | --- |
+| Images | `imagePlugin()` | `jpg`, `png`, `gif`, `webp`, `avif`, `svg`, `bmp`, `tiff`, `heic`, `heif` |
+| Video | `videoPlugin()` | `mp4`, `webm`, `mov`, `m4v`, `avi`, `mkv`, `flv`, `wmv`, `m3u8`, `m2ts` |
+| Audio | `audioPlugin()` | `mp3`, `wav`, `ogg`, `aac`, `m4a`, `flac`, `opus`, `mid`, `wma` |
+| Text / code | `textPlugin()` | `txt`, `md`, `json`, `yaml`, `xml`, `csv`, `js`, `ts`, `tsx`, `vue`, `html`, `css`, `py`, `go`, `rs`, `sql`, `sh` |
+| PDF / ebooks | `pdfPlugin()`, `epubPlugin()`, `xpsPlugin()` | `pdf`, `epub`, `xps`, `oxps` |
+| Office | `officePlugin()` | `docx`, `rtf`, `odt`, `xlsx`, `csv`, `pptx`, `odp`, `wps`, `et`, `dps` |
+| OFD | `ofdPlugin()` | `ofd` |
+| Archives | `archivePlugin()` | `zip`, `rar`, `7z`, `tar`, `gz`, `tgz`, `bz2`, `xz` |
+| Email | `emailPlugin()` | `eml`, `msg`, `mbox` |
+| Drawing / whiteboard | `drawingPlugin()` | `drawio`, `dio`, `excalidraw`, `tldraw` |
+| CAD / engineering | `cadPlugin()` | `dxf`, `dwg`, `dwf`, `step`, `stp`, `iges`, `igs`, `ifc`, `skp`, `sldprt` |
+| 3D models | `model3dPlugin()` | `gltf`, `glb`, `obj`, `stl`, `fbx`, `dae`, `ply`, `3mf`, `usd`, `usdz` |
+| GIS | `gisPlugin()` | `geojson`, `topojson`, `kml`, `kmz`, `gpx`, `shp` |
+| Asset recognition | `assetPlugin()` | `ttf`, `woff2`, `psd`, `ai`, `eps`, `sqlite`, `wasm`, `parquet`, `avro` |
+
+Preview quality for complex formats depends on browser capabilities, file structure, and the parser used by each plugin. The current version focuses on making every format enter a controlled preview path inside the container. High-fidelity Office, CAD, design, and proprietary binary formats can continue to integrate dedicated engines or server-side conversion.
+
+Plugin order matters because the first matching plugin renders the file. For example, `csv` and `tsv` can match both `textPlugin()` and `officePlugin()`; place `officePlugin()` earlier if you want spreadsheet-style table preview.
+
+## Core API
+
+```ts
+createViewer(options: PreviewOptions): FileViewer;
+```
+
+### PreviewOptions
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `container` | `HTMLElement \| string` | Required | Preview container |
+| `file` | `File \| Blob \| string \| ArrayBuffer` | - | Single-file preview source |
+| `files` | `(PreviewSource \| PreviewItem)[]` | - | Multi-file preview queue |
+| `initialIndex` | `number` | `0` | Initial file index |
+| `fileName` | `string` | Auto inferred | File name used for extension detection |
+| `mimeType` | `string` | Auto inferred | MIME type |
+| `width` | `number \| string` | Original container width | Preview container width |
+| `height` | `number \| string` | Original container height | Preview container height |
+| `fit` | `contain \| cover \| width \| height \| actual \| scale-down` | `contain` | Content fitting mode |
+| `plugins` | `PreviewPlugin[]` | `[]` | Plugin list, matched in order |
+| `fallback` | `inline \| download \| custom` | `inline` | Fallback strategy for unsupported formats |
+| `renderFallback` | `(ctx) => PreviewInstance` | - | Custom fallback renderer |
+| `toolbar` | `boolean \| PreviewToolbarOptions` | `false` | Toolbar configuration |
+| `theme` | `light \| dark \| auto` | `light` | Viewer theme |
+| `className` | `string` | - | Extra container class name |
+| `onLoad` | `(file) => void` | - | Callback after loading completes |
+| `onError` | `(error, file) => void` | - | Error callback |
+| `onUnsupported` | `(file) => void` | - | Unsupported-format callback |
+
+## Toolbar Customization
+
+`toolbar: true` enables the default toolbar, including multi-file navigation, zoom, rotate, download, fullscreen, print, and search when supported by the active plugin. You can extend it for business workflows without rewriting the whole viewer.
+
+### Custom Labels, Order, and Icons
+
+```ts
+createViewer({
+  container: "#viewer",
+  file,
+  toolbar: {
+    zoom: true,
+    rotate: true,
+    download: true,
+    fullscreen: true,
+    search: true,
+    labels: {
+      download: "Download",
+      fullscreen: "Fullscreen",
+      search: "Search",
+      "zoom-in": "Zoom in",
+      "zoom-out": "Zoom out",
+      "zoom-reset": "Actual size",
+      "rotate-right": "Rotate"
+    },
+    titles: {
+      download: "Download current file"
+    },
+    icons: {
+      download: '<svg viewBox="0 0 24 24"><path d="M12 3v12m0 0 4-4m-4 4-4-4M5 21h14"/></svg>'
+    },
+    order: ["search", "zoom-out", "zoom-in", "zoom-reset", "rotate-right", "download", "fullscreen"]
+  },
+  plugins
+});
+```
+
+### Add Business Actions
+
+```ts
+createViewer({
+  container: "#viewer",
+  file,
+  toolbar: {
+    order: ["download", "favorite", "approve", "share", "fullscreen"],
+    actions: [
+      {
+        id: "favorite",
+        label: "Favorite",
+        onClick(ctx) {
+          favoriteFile(ctx.file);
+        }
+      },
+      {
+        id: "approve",
+        label: "Approve",
+        onClick(ctx) {
+          openApprovalDialog(ctx.file);
+        }
+      },
+      {
+        id: "share",
+        label: "Share",
+        disabled(ctx) {
+          return !ctx.file;
+        },
+        onClick(ctx) {
+          shareFile(ctx.file);
+        }
+      }
+    ]
+  },
+  plugins
+});
+```
+
+### Fully Replace the Toolbar
+
+```ts
+createViewer({
+  container: "#viewer",
+  files,
+  toolbar: {
+    render(ctx) {
+      const bar = document.createElement("div");
+      bar.className = "business-toolbar";
+
+      const name = document.createElement("strong");
+      name.textContent = ctx.file?.name || "";
+
+      const next = document.createElement("button");
+      next.type = "button";
+      next.textContent = "Next";
+      next.disabled = !ctx.canNext;
+      next.onclick = () => void ctx.next();
+
+      const download = document.createElement("button");
+      download.type = "button";
+      download.textContent = "Download";
+      download.onclick = ctx.download;
+
+      bar.append(name, next, download);
+      return bar;
+    }
+  },
+  plugins
+});
+```
+
+The `render(ctx)` context includes `file`, `index`, `length`, `previous()`, `next()`, `command()`, `download()`, `fullscreen()`, `print()`, `search()`, and `clearSearch()`. In core, `toolbar.render(ctx)` returns a DOM `HTMLElement | void`; React, Vue, and Svelte expose framework-native toolbar APIs.
+
+### React Custom Toolbar
+
+```tsx
+<FileViewer
+  files={files}
+  plugins={plugins}
+  renderToolbar={(ctx) => (
+    <>
+      <button disabled={!ctx.canPrevious} onClick={() => void ctx.previous()}>Previous</button>
+      <span>{ctx.index + 1} / {ctx.length}</span>
+      <button disabled={!ctx.canNext} onClick={() => void ctx.next()}>Next</button>
+      <button onClick={ctx.download}>Download</button>
+      <button onClick={() => openApprovalDialog(ctx.file)}>Approve</button>
+    </>
+  )}
+/>
+```
+
+### Vue Custom Toolbar
+
+```vue
+<OpenFileViewer :files="files" :plugins="plugins">
+  <template #toolbar="ctx">
+    <button :disabled="!ctx.canPrevious" @click="ctx.previous()">Previous</button>
+    <span>{{ ctx.index + 1 }} / {{ ctx.length }}</span>
+    <button :disabled="!ctx.canNext" @click="ctx.next()">Next</button>
+    <button @click="ctx.download()">Download</button>
+    <button @click="openApprovalDialog(ctx.file)">Approve</button>
+  </template>
+</OpenFileViewer>
+```
+
+### Svelte Custom Toolbar
+
+```svelte
+<OpenFileViewer files={files} plugins={plugins}>
+  <svelte:fragment slot="toolbar" let:ctx>
+    {#if ctx}
+      <button disabled={!ctx.canPrevious} on:click={() => void ctx.previous()}>Previous</button>
+      <span>{ctx.index + 1} / {ctx.length}</span>
+      <button disabled={!ctx.canNext} on:click={() => void ctx.next()}>Next</button>
+      <button on:click={ctx.download}>Download</button>
+      <button on:click={() => openApprovalDialog(ctx.file)}>Approve</button>
+    {/if}
+  </svelte:fragment>
+</OpenFileViewer>
+```
+
+At the style layer, you can still override classes such as `.ofv-toolbar`, `.ofv-toolbar button`, and `.ofv-toolbar-search`. Custom icon buttons also generate `.ofv-toolbar-icon` and `.ofv-toolbar-label`, making alignment, spacing, and truncation easier to control.
+
+### FileViewer
+
+| Method | Description |
+| --- | --- |
+| `reload(file?)` | Reload the current file or a specified file |
+| `next()` / `previous()` | Switch through the multi-file queue |
+| `goTo(index)` | Jump to a specified file |
+| `getCurrentIndex()` | Get the current index |
+| `resize()` | Manually trigger size recalculation |
+| `destroy()` | Destroy the viewer and clean up resources |
+
+## Plugin Development
+
+Each format is integrated through a plugin. A plugin only needs to answer two questions: whether the file matches, and how to render into `ctx.viewport`.
+
+```ts
+import type { PreviewPlugin } from "@open-file-viewer/core";
+
+export function customPlugin(): PreviewPlugin {
+  return {
+    name: "custom",
+    match(file) {
+      return file.extension === "custom";
+    },
+    async render(ctx) {
+      const element = document.createElement("div");
+      element.textContent = ctx.file.name;
+      ctx.viewport.append(element);
+
+      return {
+        resize(size) {
+          console.log("container resized", size);
+        },
+        destroy() {
+          element.remove();
+        }
+      };
+    }
+  };
+}
+```
+
+Plugin constraints:
+
+- Render only into `ctx.viewport`.
+- Do not open a new window by default.
+- Implement `resize(size)` when the plugin needs to react to container size changes.
+- Implement `destroy()` to clean up events, object URLs, timers, Canvas/WebGL resources, and other side effects.
+
+## Package Structure
+
+```txt
+packages/
+  core/      # Framework-agnostic preview core and plugins
+  react/     # React adapter
+  vue/       # Vue adapter
+  svelte/    # Svelte adapter
+examples/
+  vanilla/   # Vanilla JavaScript example
+  react/     # React example
+  vue/       # Vue example
+  svelte/    # Svelte example
+doc/         # Website and online experience
+```
+
+## Local Development
+
+```bash
+pnpm install
+pnpm check
+```
+
+Common commands:
+
+```bash
+pnpm dev:doc
+pnpm dev:vanilla
+pnpm dev:react
+pnpm dev:vue
+pnpm dev:svelte
+pnpm test
+pnpm typecheck
+pnpm build
+pnpm build:examples
+pnpm build:doc
+pnpm pack:check
+```
+
+`pnpm check` runs tests, type checks, package builds, example builds, website build, and package export validation in sequence.
+
+## Roadmap
+
+| Version | Focus |
+| --- | --- |
+| `0.1.x` | Core plugin system, in-container preview, React/Vue/Svelte/Vanilla integration, basic multi-format preview |
+| `0.2.x` | Toolbar, themes, image interactions, PDF search, unified states, and fallback |
+| `0.3.x` | Markdown/code reader, enhanced Office spreadsheets and document experience |
+| `0.4.x` | OFD, email, archives, drawing files, and enhancements for high-frequency domestic business formats |
+| `0.5.x` | CAD, 3D, GIS, dedicated parsers, and server-side conversion collaboration |
+| `1.0.0` | Stable API, complete documentation site, visual regression tests, and plugin development guide |
+
+## Community and Support
+
+Open File Viewer will continue improving format preview, framework integration, and real business scenarios. Open source is not easy. If it saves you development time, a free GitHub star is a meaningful way to support future iteration.
+
+- Feedback: use GitHub Issues, the community group, or the author's WeChat to share file samples, layout problems, container adaptation issues, and new format requests.
+- Learning and discussion: the official account "Frontend Development Enthusiasts" will continue sharing frontend engineering, component development, and open-source practice.
+- Support the author: if you would like to buy the author a coffee, or even a bottle of mineral water, that encouragement is appreciated. Donation users are welcome to add the author's WeChat for future frontend discussions.
+
+<table>
+  <tr>
+    <td align="center" width="20%">
+      <img src="./doc/public/images/official-account-qr.jpg" width="140" alt="Official account QR code: Frontend Development Enthusiasts" />
+      <br />
+      <strong>Official Account</strong>
+      <br />
+      Frontend Development Enthusiasts
+    </td>
+    <td align="center" width="20%">
+      <img src="./doc/public/images/community-group-qr.png" width="140" alt="Community group QR code" />
+      <br />
+      <strong>Community Group</strong>
+      <br />
+      Frontend technology discussion
+    </td>
+    <td align="center" width="20%">
+      <img src="./doc/public/images/author-wechat-qr.png" width="140" alt="Author WeChat QR code" />
+      <br />
+      <strong>Author WeChat</strong>
+      <br />
+      Frontend discussion
+    </td>
+    <td align="center" width="20%">
+      <img src="./doc/public/images/wechat-donation-qr.png" width="140" alt="WeChat donation QR code" />
+      <br />
+      <strong>WeChat Donation</strong>
+      <br />
+      Buy the author a coffee
+    </td>
+    <td align="center" width="20%">
+      <img src="./doc/public/images/alipay-donation-qr.png" width="140" alt="Alipay donation QR code" />
+      <br />
+      <strong>Alipay Donation</strong>
+      <br />
+      Buy the author a bottle of water
+    </td>
+  </tr>
+</table>
+
+## Links
+
+- Website: https://open-file-viewer-workspace.void.app
+- About: https://open-file-viewer-workspace.void.app/about.html
+- GitHub: https://github.com/xushanpei/open-file-viewer
+- NPM Core: https://www.npmjs.com/package/@open-file-viewer/core
+- NPM React: https://www.npmjs.com/package/@open-file-viewer/react
+- NPM Vue: https://www.npmjs.com/package/@open-file-viewer/vue
+- NPM Svelte: https://www.npmjs.com/package/@open-file-viewer/svelte
+
+## License
+
+[MIT](./LICENSE)

--- a/README.es.md
+++ b/README.es.md
@@ -1,25 +1,25 @@
 # Open File Viewer
 
 <p align="right">
-  <a href="./README.md">Simplified Chinese</a>
+  <a href="./README.md">简体中文</a>
   |
-  <strong>English</strong>
+  <a href="./README.en.md">English</a>
   |
   <a href="./README.ja.md">日本語</a>
   |
   <a href="./README.ko.md">한국어</a>
   |
-  <a href="./README.es.md">Español</a>
+  <strong>Español</strong>
   |
   <a href="./README.pt-BR.md">Português</a>
 </p>
 
-Open File Viewer is a file preview SDK for modern web applications. It brings PDFs, Office documents, images, audio and video, archives, emails, drawings, 3D files, GIS data, and source code into one controlled container, with support for vanilla JavaScript, React, Vue, and Svelte.
+Open File Viewer es un SDK de vista previa de archivos para aplicaciones web modernas. Permite mostrar PDF, documentos de Office, imágenes, audio y video, archivos comprimidos, correos, planos, archivos 3D, datos GIS y código fuente dentro de un único contenedor controlado, con soporte para JavaScript nativo, React, Vue y Svelte.
 
 <p>
-  <a href="https://open-file-viewer-workspace.void.app">Website</a>
+  <a href="https://open-file-viewer-workspace.void.app">Sitio web</a>
   |
-  <a href="https://open-file-viewer-workspace.void.app/about.html">About</a>
+  <a href="https://open-file-viewer-workspace.void.app/about.html">Acerca de</a>
   |
   <a href="https://github.com/xushanpei/open-file-viewer">GitHub</a>
   |
@@ -39,18 +39,18 @@ Open File Viewer is a file preview SDK for modern web applications. It brings PD
 [![Svelte](https://img.shields.io/npm/v/@open-file-viewer/svelte?label=svelte&color=ff3e00)](https://www.npmjs.com/package/@open-file-viewer/svelte)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
-## Why Choose It
+## Por Que Elegirlo
 
-Most business systems eventually need attachment preview: contracts, spreadsheets, drawings, archives, emails, images, videos, and source files. Open File Viewer is not a PDF-only demo. It is a file preview foundation that can evolve with real product needs over time.
+La mayoría de los sistemas empresariales terminan necesitando vista previa de adjuntos: contratos, hojas de cálculo, planos, archivos comprimidos, correos, imágenes, videos y archivos fuente. Open File Viewer no es una demo que solo abre PDF; es una base de vista previa de archivos que puede evolucionar con necesidades reales de producto.
 
-- **Container-first**: all content renders inside the DOM container you provide. It does not open a new window or interrupt the host business page.
-- **Multi-framework compatibility**: vanilla JavaScript, React, Vue, and Svelte share the same core capabilities.
-- **Plugin-based formats**: each file format is handled by an independent plugin, making behavior easier to replace, trim, and extend.
-- **Responsive preview**: supports CSS sizes such as `px`, `%`, `vh`, `vw`, `rem`, and `calc()`, and responds automatically to container changes.
-- **Application-ready states**: includes loading, error, unsupported, download fallback, toolbar, theme, and multi-file queue behavior.
-- **Progressive enhancement for complex formats**: formats that browsers can preview directly are rendered locally first; complex formats can gradually integrate WASM, dedicated parsers, or server-side conversion.
+- **Contenedor primero**: todo el contenido se renderiza dentro del contenedor DOM que proporcionas. No abre una nueva ventana ni interrumpe la página de negocio.
+- **Compatibilidad con varios frameworks**: JavaScript nativo, React, Vue y Svelte comparten las mismas capacidades del core.
+- **Formatos basados en plugins**: cada formato de archivo lo maneja un plugin independiente, lo que facilita reemplazar, recortar y extender comportamiento.
+- **Vista previa responsiva**: admite tamaños CSS como `px`, `%`, `vh`, `vw`, `rem` y `calc()`, y responde automáticamente a cambios del contenedor.
+- **Estados listos para aplicaciones**: incluye loading, error, unsupported, download fallback, toolbar, theme y cola de múltiples archivos.
+- **Mejora progresiva para formatos complejos**: los formatos que el navegador puede previsualizar directamente se renderizan localmente primero; los formatos complejos pueden integrar gradualmente WASM, parsers dedicados o conversión del lado del servidor.
 
-## Installation
+## Instalación
 
 ```bash
 pnpm add @open-file-viewer/core
@@ -74,28 +74,28 @@ Svelte:
 pnpm add @open-file-viewer/core @open-file-viewer/svelte
 ```
 
-PDF preview requires `pdfjs-dist` when you use `pdfPlugin()`:
+La vista previa de PDF requiere `pdfjs-dist` cuando usas `pdfPlugin()`:
 
 ```bash
 pnpm add pdfjs-dist
 ```
 
-You can also use npm or yarn:
+También puedes usar npm o yarn:
 
 ```bash
 npm install @open-file-viewer/core
 yarn add @open-file-viewer/core
 ```
 
-Import the shared stylesheet once in your application:
+Importa la hoja de estilos compartida una vez en tu aplicación:
 
 ```ts
 import "@open-file-viewer/core/style.css";
 ```
 
-## Quick Start
+## Inicio Rápido
 
-### Vanilla JavaScript
+### JavaScript Nativo
 
 ```ts
 import {
@@ -242,53 +242,53 @@ const plugins = [
 />
 ```
 
-## Use Cases
+## Casos de Uso
 
-| Scenario | What Open File Viewer Provides |
+| Escenario | Qué Proporciona Open File Viewer |
 | --- | --- |
-| OA / ERP / CRM attachment centers | A unified container preview for contracts, spreadsheets, images, emails, and archives |
-| Cloud drives / knowledge bases / document systems | Multi-file queues, download, search, fullscreen, and theme adaptation |
-| Low-code / form systems | Vanilla JS integration without forcing React, Vue, or Svelte |
-| Engineering / manufacturing / GIS systems | Recognition and progressive enhancement for CAD, 3D, GIS, and drawing files |
-| Developer platforms / log platforms | Text, config, Markdown, code highlighting, and large-file protection |
+| Centros de adjuntos OA / ERP / CRM | Vista previa unificada en contenedor para contratos, hojas de cálculo, imágenes, correos y archivos comprimidos |
+| Unidades en la nube / bases de conocimiento / sistemas documentales | Cola de múltiples archivos, descarga, búsqueda, pantalla completa y adaptación de tema |
+| Sistemas low-code / formularios | Integración con JavaScript nativo sin depender obligatoriamente de React, Vue o Svelte |
+| Ingeniería / manufactura / sistemas GIS | Reconocimiento y mejora progresiva para archivos CAD, 3D, GIS y planos |
+| Plataformas de desarrollo / logs | Texto, configuración, Markdown, resaltado de código y protección para archivos grandes |
 
-## Feature Overview
+## Resumen de Capacidades
 
-| Capability | Status |
+| Capacidad | Estado |
 | --- | --- |
-| Vanilla JS / React / Vue / Svelte integration | Supported |
-| Custom container, width, height, and responsive sizing | Supported |
-| Multi-file queue, switching, and current index | Supported |
-| Toolbar, download, fullscreen, print, and search | Supported |
-| Light, dark, and `auto` themes | Supported |
-| Local `File` / `Blob` / URL / `ArrayBuffer` sources | Supported |
-| Plugin protocol and custom fallback | Supported |
-| PDF, images, audio/video, text/code | Supported |
-| Office, OFD, EPUB, XPS, email, and archives | Basic to enhanced preview |
-| CAD, 3D, GIS, drawing boards, and design assets | Detection, basic preview, and ongoing enhancements |
+| Integración con JS nativo / React / Vue / Svelte | Soportado |
+| Contenedor, ancho, alto y tamaño responsivo personalizados | Soportado |
+| Cola de múltiples archivos, cambio e índice actual | Soportado |
+| Toolbar, descarga, pantalla completa, impresión y búsqueda | Soportado |
+| Temas light, dark y `auto` | Soportado |
+| Fuentes locales `File` / `Blob` / URL / `ArrayBuffer` | Soportado |
+| Protocolo de plugins y fallback personalizado | Soportado |
+| PDF, imágenes, audio/video, texto/código | Soportado |
+| Office, OFD, EPUB, XPS, correo y archivos comprimidos | Vista previa básica a mejorada |
+| CAD, 3D, GIS, tableros de dibujo y activos de diseño | Reconocimiento, vista previa básica y mejoras continuas |
 
-## Format Coverage
+## Cobertura de Formatos
 
-| Category | Plugin | Representative Formats |
+| Categoría | Plugin | Formatos Representativos |
 | --- | --- | --- |
-| Images | `imagePlugin()` | `jpg`, `png`, `gif`, `webp`, `avif`, `svg`, `bmp`, `tiff`, `heic`, `heif` |
+| Imágenes | `imagePlugin()` | `jpg`, `png`, `gif`, `webp`, `avif`, `svg`, `bmp`, `tiff`, `heic`, `heif` |
 | Video | `videoPlugin()` | `mp4`, `webm`, `mov`, `m4v`, `avi`, `mkv`, `flv`, `wmv`, `m3u8`, `m2ts` |
 | Audio | `audioPlugin()` | `mp3`, `wav`, `ogg`, `aac`, `m4a`, `flac`, `opus`, `mid`, `wma` |
-| Text / code | `textPlugin()` | `txt`, `md`, `json`, `yaml`, `xml`, `csv`, `js`, `ts`, `tsx`, `vue`, `html`, `css`, `py`, `go`, `rs`, `sql`, `sh` |
+| Texto / código | `textPlugin()` | `txt`, `md`, `json`, `yaml`, `xml`, `csv`, `js`, `ts`, `tsx`, `vue`, `html`, `css`, `py`, `go`, `rs`, `sql`, `sh` |
 | PDF / ebooks | `pdfPlugin()`, `epubPlugin()`, `xpsPlugin()` | `pdf`, `epub`, `xps`, `oxps` |
 | Office | `officePlugin()` | `docx`, `rtf`, `odt`, `xlsx`, `csv`, `pptx`, `odp`, `wps`, `et`, `dps` |
 | OFD | `ofdPlugin()` | `ofd` |
-| Archives | `archivePlugin()` | `zip`, `rar`, `7z`, `tar`, `gz`, `tgz`, `bz2`, `xz` |
+| Archivos comprimidos | `archivePlugin()` | `zip`, `rar`, `7z`, `tar`, `gz`, `tgz`, `bz2`, `xz` |
 | Email | `emailPlugin()` | `eml`, `msg`, `mbox` |
-| Drawing / whiteboard | `drawingPlugin()` | `drawio`, `dio`, `excalidraw`, `tldraw` |
-| CAD / engineering | `cadPlugin()` | `dxf`, `dwg`, `dwf`, `step`, `stp`, `iges`, `igs`, `ifc`, `skp`, `sldprt` |
-| 3D models | `model3dPlugin()` | `gltf`, `glb`, `obj`, `stl`, `fbx`, `dae`, `ply`, `3mf`, `usd`, `usdz` |
+| Dibujo / pizarra | `drawingPlugin()` | `drawio`, `dio`, `excalidraw`, `tldraw` |
+| CAD / ingeniería | `cadPlugin()` | `dxf`, `dwg`, `dwf`, `step`, `stp`, `iges`, `igs`, `ifc`, `skp`, `sldprt` |
+| Modelos 3D | `model3dPlugin()` | `gltf`, `glb`, `obj`, `stl`, `fbx`, `dae`, `ply`, `3mf`, `usd`, `usdz` |
 | GIS | `gisPlugin()` | `geojson`, `topojson`, `kml`, `kmz`, `gpx`, `shp` |
-| Asset recognition | `assetPlugin()` | `ttf`, `woff2`, `psd`, `ai`, `eps`, `sqlite`, `wasm`, `parquet`, `avro` |
+| Reconocimiento de activos | `assetPlugin()` | `ttf`, `woff2`, `psd`, `ai`, `eps`, `sqlite`, `wasm`, `parquet`, `avro` |
 
-Preview quality for complex formats depends on browser capabilities, file structure, and the parser used by each plugin. The current version focuses on making every format enter a controlled preview path inside the container. High-fidelity Office, CAD, design, and proprietary binary formats can continue to integrate dedicated engines or server-side conversion.
+La calidad de vista previa para formatos complejos depende de las capacidades del navegador, la estructura del archivo y el parser usado por cada plugin. La versión actual prioriza que todos los formatos entren en una ruta de vista previa controlada dentro del contenedor. Los formatos Office, CAD, de diseño y binarios propietarios de alta fidelidad pueden seguir mejorándose con motores dedicados o conversión del lado del servidor.
 
-Plugin order matters because the first matching plugin renders the file. For example, `csv` and `tsv` can match both `textPlugin()` and `officePlugin()`; place `officePlugin()` earlier if you want spreadsheet-style table preview.
+El orden de los plugins importa porque el primer plugin que coincide renderiza el archivo. Por ejemplo, `csv` y `tsv` pueden coincidir tanto con `textPlugin()` como con `officePlugin()`; coloca `officePlugin()` antes si quieres una vista previa de tabla tipo hoja de cálculo.
 
 ## Core API
 
@@ -298,32 +298,32 @@ createViewer(options: PreviewOptions): FileViewer;
 
 ### PreviewOptions
 
-| Option | Type | Default | Description |
+| Opción | Tipo | Valor por Defecto | Descripción |
 | --- | --- | --- | --- |
-| `container` | `HTMLElement \| string` | Required | Preview container |
-| `file` | `File \| Blob \| string \| ArrayBuffer` | - | Single-file preview source |
-| `files` | `(PreviewSource \| PreviewItem)[]` | - | Multi-file preview queue |
-| `initialIndex` | `number` | `0` | Initial file index |
-| `fileName` | `string` | Auto inferred | File name used for extension detection |
-| `mimeType` | `string` | Auto inferred | MIME type |
-| `width` | `number \| string` | Original container width | Preview container width |
-| `height` | `number \| string` | Original container height | Preview container height |
-| `fit` | `contain \| cover \| width \| height \| actual \| scale-down` | `contain` | Content fitting mode |
-| `plugins` | `PreviewPlugin[]` | `[]` | Plugin list, matched in order |
-| `fallback` | `inline \| download \| custom` | `inline` | Fallback strategy for unsupported formats |
-| `renderFallback` | `(ctx) => PreviewInstance` | - | Custom fallback renderer |
-| `toolbar` | `boolean \| PreviewToolbarOptions` | `false` | Toolbar configuration |
-| `theme` | `light \| dark \| auto` | `light` | Viewer theme |
-| `className` | `string` | - | Extra container class name |
-| `onLoad` | `(file) => void` | - | Callback after loading completes |
-| `onError` | `(error, file) => void` | - | Error callback |
-| `onUnsupported` | `(file) => void` | - | Unsupported-format callback |
+| `container` | `HTMLElement \| string` | Requerido | Contenedor de vista previa |
+| `file` | `File \| Blob \| string \| ArrayBuffer` | - | Fuente de vista previa de un solo archivo |
+| `files` | `(PreviewSource \| PreviewItem)[]` | - | Cola de vista previa de múltiples archivos |
+| `initialIndex` | `number` | `0` | Índice inicial del archivo |
+| `fileName` | `string` | Inferido automáticamente | Nombre usado para detectar extensión |
+| `mimeType` | `string` | Inferido automáticamente | Tipo MIME |
+| `width` | `number \| string` | Ancho original del contenedor | Ancho del contenedor |
+| `height` | `number \| string` | Alto original del contenedor | Alto del contenedor |
+| `fit` | `contain \| cover \| width \| height \| actual \| scale-down` | `contain` | Modo de ajuste del contenido |
+| `plugins` | `PreviewPlugin[]` | `[]` | Lista de plugins, evaluada en orden |
+| `fallback` | `inline \| download \| custom` | `inline` | Estrategia fallback para formatos no soportados |
+| `renderFallback` | `(ctx) => PreviewInstance` | - | Renderer fallback personalizado |
+| `toolbar` | `boolean \| PreviewToolbarOptions` | `false` | Configuración de toolbar |
+| `theme` | `light \| dark \| auto` | `light` | Tema del viewer |
+| `className` | `string` | - | Clase extra para el contenedor |
+| `onLoad` | `(file) => void` | - | Callback al completar carga |
+| `onError` | `(error, file) => void` | - | Callback de error |
+| `onUnsupported` | `(file) => void` | - | Callback para formato no soportado |
 
-## Toolbar Customization
+## Personalización de Toolbar
 
-`toolbar: true` enables the default toolbar, including multi-file navigation, zoom, rotate, download, fullscreen, print, and search when supported by the active plugin. You can extend it for business workflows without rewriting the whole viewer.
+`toolbar: true` habilita la toolbar predeterminada, incluyendo navegación de múltiples archivos, zoom, rotación, descarga, pantalla completa, impresión y búsqueda cuando el plugin activo lo soporta. Puedes extenderla para flujos de negocio sin reescribir todo el viewer.
 
-### Custom Labels, Order, and Icons
+### Labels, Orden e Iconos Personalizados
 
 ```ts
 createViewer({
@@ -356,7 +356,7 @@ createViewer({
 });
 ```
 
-### Add Business Actions
+### Agregar Acciones de Negocio
 
 ```ts
 createViewer({
@@ -395,7 +395,7 @@ createViewer({
 });
 ```
 
-### Fully Replace the Toolbar
+### Reemplazar Completamente la Toolbar
 
 ```ts
 createViewer({
@@ -428,9 +428,9 @@ createViewer({
 });
 ```
 
-The `render(ctx)` context includes `file`, `index`, `length`, `previous()`, `next()`, `command()`, `download()`, `fullscreen()`, `print()`, `search()`, and `clearSearch()`. In core, `toolbar.render(ctx)` returns a DOM `HTMLElement | void`; React, Vue, and Svelte expose framework-native toolbar APIs.
+El contexto `render(ctx)` incluye `file`, `index`, `length`, `previous()`, `next()`, `command()`, `download()`, `fullscreen()`, `print()`, `search()` y `clearSearch()`. En core, `toolbar.render(ctx)` devuelve un DOM `HTMLElement | void`; React, Vue y Svelte exponen APIs de toolbar nativas para cada framework.
 
-### React Custom Toolbar
+### Toolbar Personalizada en React
 
 ```tsx
 <FileViewer
@@ -448,7 +448,7 @@ The `render(ctx)` context includes `file`, `index`, `length`, `previous()`, `nex
 />
 ```
 
-### Vue Custom Toolbar
+### Toolbar Personalizada en Vue
 
 ```vue
 <OpenFileViewer :files="files" :plugins="plugins">
@@ -462,7 +462,7 @@ The `render(ctx)` context includes `file`, `index`, `length`, `previous()`, `nex
 </OpenFileViewer>
 ```
 
-### Svelte Custom Toolbar
+### Toolbar Personalizada en Svelte
 
 ```svelte
 <OpenFileViewer files={files} plugins={plugins}>
@@ -478,22 +478,22 @@ The `render(ctx)` context includes `file`, `index`, `length`, `previous()`, `nex
 </OpenFileViewer>
 ```
 
-At the style layer, you can still override classes such as `.ofv-toolbar`, `.ofv-toolbar button`, and `.ofv-toolbar-search`. Custom icon buttons also generate `.ofv-toolbar-icon` and `.ofv-toolbar-label`, making alignment, spacing, and truncation easier to control.
+En la capa de estilos, puedes seguir sobrescribiendo clases como `.ofv-toolbar`, `.ofv-toolbar button` y `.ofv-toolbar-search`. Los botones con iconos personalizados también generan `.ofv-toolbar-icon` y `.ofv-toolbar-label`, lo que facilita controlar alineación, espaciado y truncado.
 
 ### FileViewer
 
-| Method | Description |
+| Método | Descripción |
 | --- | --- |
-| `reload(file?)` | Reload the current file or a specified file |
-| `next()` / `previous()` | Switch through the multi-file queue |
-| `goTo(index)` | Jump to a specified file |
-| `getCurrentIndex()` | Get the current index |
-| `resize()` | Manually trigger size recalculation |
-| `destroy()` | Destroy the viewer and clean up resources |
+| `reload(file?)` | Recarga el archivo actual o uno especificado |
+| `next()` / `previous()` | Cambia dentro de la cola de múltiples archivos |
+| `goTo(index)` | Salta a un archivo específico |
+| `getCurrentIndex()` | Obtiene el índice actual |
+| `resize()` | Dispara manualmente el recálculo de tamaño |
+| `destroy()` | Destruye el viewer y limpia recursos |
 
-## Plugin Development
+## Desarrollo de Plugins
 
-Each format is integrated through a plugin. A plugin only needs to answer two questions: whether the file matches, and how to render into `ctx.viewport`.
+Cada formato se integra mediante un plugin. Un plugin solo necesita responder dos preguntas: si el archivo coincide y cómo renderizar en `ctx.viewport`.
 
 ```ts
 import type { PreviewPlugin } from "@open-file-viewer/core";
@@ -522,37 +522,37 @@ export function customPlugin(): PreviewPlugin {
 }
 ```
 
-Plugin constraints:
+Restricciones de plugins:
 
-- Render only into `ctx.viewport`.
-- Do not open a new window by default.
-- Implement `resize(size)` when the plugin needs to react to container size changes.
-- Implement `destroy()` to clean up events, object URLs, timers, Canvas/WebGL resources, and other side effects.
+- Renderizar solo dentro de `ctx.viewport`.
+- No abrir una nueva ventana por defecto.
+- Implementar `resize(size)` cuando el plugin necesite reaccionar a cambios de tamaño del contenedor.
+- Implementar `destroy()` para limpiar eventos, Object URLs, temporizadores, recursos Canvas/WebGL y otros efectos secundarios.
 
-## Package Structure
+## Estructura de Paquetes
 
 ```txt
 packages/
-  core/      # Framework-agnostic preview core and plugins
-  react/     # React adapter
-  vue/       # Vue adapter
-  svelte/    # Svelte adapter
+  core/      # Core de vista previa y plugins independientes del framework
+  react/     # Adaptador React
+  vue/       # Adaptador Vue
+  svelte/    # Adaptador Svelte
 examples/
-  vanilla/   # Vanilla JavaScript example
-  react/     # React example
-  vue/       # Vue example
-  svelte/    # Svelte example
-doc/         # Website and online experience
+  vanilla/   # Ejemplo con JavaScript nativo
+  react/     # Ejemplo React
+  vue/       # Ejemplo Vue
+  svelte/    # Ejemplo Svelte
+doc/         # Sitio web y experiencia online
 ```
 
-## Local Development
+## Desarrollo Local
 
 ```bash
 pnpm install
 pnpm check
 ```
 
-Common commands:
+Comandos comunes:
 
 ```bash
 pnpm dev:doc
@@ -568,26 +568,26 @@ pnpm build:doc
 pnpm pack:check
 ```
 
-`pnpm check` runs tests, type checks, package builds, example builds, website build, and package export validation in sequence.
+`pnpm check` ejecuta en secuencia pruebas, type checks, builds de packages, builds de examples, build del sitio web y validación de package exports.
 
 ## Roadmap
 
-| Version | Focus |
+| Versión | Foco |
 | --- | --- |
-| `0.1.x` | Core plugin system, in-container preview, React/Vue/Svelte/Vanilla integration, basic multi-format preview |
-| `0.2.x` | Toolbar, themes, image interactions, PDF search, unified states, and fallback |
-| `0.3.x` | Markdown/code reader, enhanced Office spreadsheets and document experience |
-| `0.4.x` | OFD, email, archives, drawing files, and enhancements for high-frequency domestic business formats |
-| `0.5.x` | CAD, 3D, GIS, dedicated parsers, and server-side conversion collaboration |
-| `1.0.0` | Stable API, complete documentation site, visual regression tests, and plugin development guide |
+| `0.1.x` | Sistema de plugins core, vista previa dentro del contenedor, integración React/Vue/Svelte/Vanilla, vista previa básica multiformato |
+| `0.2.x` | Toolbar, temas, interacción con imágenes, búsqueda en PDF, estados unificados y fallback |
+| `0.3.x` | Lector Markdown/código, mejora de hojas de cálculo y documentos Office |
+| `0.4.x` | OFD, correo, archivos comprimidos, dibujos y mejoras para formatos frecuentes en negocios domésticos chinos |
+| `0.5.x` | CAD, 3D, GIS, parsers dedicados y colaboración con conversión del lado del servidor |
+| `1.0.0` | API estable, sitio de documentación completo, pruebas visuales de regresión y guía de desarrollo de plugins |
 
-## Community and Support
+## Comunidad y Soporte
 
-Open File Viewer will continue improving format preview, framework integration, and real business scenarios. Open source is not easy. If it saves you development time, a free GitHub star is a meaningful way to support future iteration.
+Open File Viewer seguirá mejorando la vista previa de más formatos, la integración con frameworks y escenarios reales de negocio. Mantener código abierto no es fácil. Si te ahorra tiempo de integración, una estrella en GitHub ayuda mucho a que el proyecto siga avanzando.
 
-- Feedback: use GitHub Issues, the community group, or the author's WeChat to share file samples, layout problems, container adaptation issues, and new format requests.
-- Learning and discussion: the official account "Frontend Development Enthusiasts" will continue sharing frontend engineering, component development, and open-source practice.
-- Support the author: if you would like to buy the author a coffee, or even a bottle of mineral water, that encouragement is appreciated. Donation users are welcome to add the author's WeChat for future frontend discussions.
+- Feedback: usa GitHub Issues, el grupo de comunidad o el WeChat del autor para compartir muestras de archivos, problemas de layout, adaptación de contenedor y solicitudes de nuevos formatos.
+- Aprendizaje y discusión: la cuenta oficial "Frontend Development Enthusiasts" seguirá compartiendo ingeniería frontend, desarrollo de componentes y práctica open source.
+- Apoyo al autor: si quieres invitar al autor a un café o incluso una botella de agua mineral, ese apoyo se agradece. Los usuarios que donen pueden agregar el WeChat del autor para futuras conversaciones sobre frontend.
 
 <table>
   <tr>
@@ -629,10 +629,10 @@ Open File Viewer will continue improving format preview, framework integration, 
   </tr>
 </table>
 
-## Links
+## Enlaces
 
-- Website: https://open-file-viewer-workspace.void.app
-- About: https://open-file-viewer-workspace.void.app/about.html
+- Sitio web: https://open-file-viewer-workspace.void.app
+- Acerca de: https://open-file-viewer-workspace.void.app/about.html
 - GitHub: https://github.com/xushanpei/open-file-viewer
 - NPM Core: https://www.npmjs.com/package/@open-file-viewer/core
 - NPM React: https://www.npmjs.com/package/@open-file-viewer/react

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,0 +1,644 @@
+# Open File Viewer
+
+<p align="right">
+  <a href="./README.md">简体中文</a>
+  |
+  <a href="./README.en.md">English</a>
+  |
+  <strong>日本語</strong>
+  |
+  <a href="./README.ko.md">한국어</a>
+  |
+  <a href="./README.es.md">Español</a>
+  |
+  <a href="./README.pt-BR.md">Português</a>
+</p>
+
+Open File Viewer は、モダンな Web プロダクト向けのファイルプレビュー SDK です。PDF、Office ドキュメント、画像、音声・動画、アーカイブ、メール、図面、3D ファイル、GIS データ、ソースコードを、1 つの制御可能なコンテナ内で扱えます。Vanilla JavaScript、React、Vue、Svelte を同時にサポートします。
+
+<p>
+  <a href="https://open-file-viewer-workspace.void.app">Web サイト</a>
+  |
+  <a href="https://open-file-viewer-workspace.void.app/about.html">About</a>
+  |
+  <a href="https://github.com/xushanpei/open-file-viewer">GitHub</a>
+  |
+  <a href="https://www.npmjs.com/package/@open-file-viewer/core">NPM Core</a>
+  |
+  <a href="https://www.npmjs.com/package/@open-file-viewer/react">React</a>
+  |
+  <a href="https://www.npmjs.com/package/@open-file-viewer/vue">Vue</a>
+  |
+  <a href="https://www.npmjs.com/package/@open-file-viewer/svelte">Svelte</a>
+</p>
+
+[![GitHub](https://img.shields.io/badge/GitHub-xushanpei%2Fopen--file--viewer-111827?logo=github)](https://github.com/xushanpei/open-file-viewer)
+[![Core](https://img.shields.io/npm/v/@open-file-viewer/core?label=%40open-file-viewer%2Fcore&color=7c5cff)](https://www.npmjs.com/package/@open-file-viewer/core)
+[![React](https://img.shields.io/npm/v/@open-file-viewer/react?label=react&color=149eca)](https://www.npmjs.com/package/@open-file-viewer/react)
+[![Vue](https://img.shields.io/npm/v/@open-file-viewer/vue?label=vue&color=41b883)](https://www.npmjs.com/package/@open-file-viewer/vue)
+[![Svelte](https://img.shields.io/npm/v/@open-file-viewer/svelte?label=svelte&color=ff3e00)](https://www.npmjs.com/package/@open-file-viewer/svelte)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
+
+## 選ばれる理由
+
+多くの業務システムでは、契約書、表計算、図面、アーカイブ、メール、画像、動画、ソースファイルなど、添付ファイルのプレビューが必要になります。Open File Viewer は PDF だけを開くデモではなく、実際のプロダクト要件に合わせて長期的に進化できるファイルプレビューの基盤です。
+
+- **コンテナ優先**: すべての内容は、指定した DOM コンテナ内にレンダリングされます。新しいウィンドウを開かず、業務ページを中断しません。
+- **複数フレームワーク対応**: Vanilla JavaScript、React、Vue、Svelte が同じ core 機能を共有します。
+- **プラグインベースの形式対応**: 各ファイル形式は独立したプラグインが担当するため、置き換え、削減、拡張がしやすくなります。
+- **レスポンシブプレビュー**: `px`、`%`、`vh`、`vw`、`rem`、`calc()` などの CSS サイズをサポートし、コンテナの変化に自動で追従します。
+- **アプリケーション向けの状態管理**: loading、error、unsupported、download fallback、ツールバー、テーマ、複数ファイルキューを備えています。
+- **複雑な形式の段階的強化**: ブラウザで直接プレビューできる形式はローカルで優先的にレンダリングし、複雑な形式は WASM、専用パーサー、サーバーサイド変換を段階的に組み込めます。
+
+## インストール
+
+```bash
+pnpm add @open-file-viewer/core
+```
+
+React:
+
+```bash
+pnpm add @open-file-viewer/core @open-file-viewer/react
+```
+
+Vue:
+
+```bash
+pnpm add @open-file-viewer/core @open-file-viewer/vue
+```
+
+Svelte:
+
+```bash
+pnpm add @open-file-viewer/core @open-file-viewer/svelte
+```
+
+`pdfPlugin()` を使用する場合、PDF プレビューには `pdfjs-dist` が必要です。
+
+```bash
+pnpm add pdfjs-dist
+```
+
+npm または yarn も利用できます。
+
+```bash
+npm install @open-file-viewer/core
+yarn add @open-file-viewer/core
+```
+
+共有スタイルはアプリケーション内で一度だけ import してください。
+
+```ts
+import "@open-file-viewer/core/style.css";
+```
+
+## クイックスタート
+
+### Vanilla JavaScript
+
+```ts
+import {
+  createViewer,
+  imagePlugin,
+  videoPlugin,
+  audioPlugin,
+  textPlugin,
+  pdfPlugin,
+  officePlugin,
+  archivePlugin,
+  emailPlugin,
+  drawingPlugin,
+  cadPlugin,
+  model3dPlugin,
+  gisPlugin,
+  fallbackPlugin
+} from "@open-file-viewer/core";
+import "@open-file-viewer/core/style.css";
+import pdfWorkerSrc from "pdfjs-dist/build/pdf.worker.mjs?url";
+
+const viewer = createViewer({
+  container: "#viewer",
+  file: fileOrUrl,
+  fileName: "contract.pdf",
+  width: "100%",
+  height: "70vh",
+  fit: "contain",
+  toolbar: true,
+  theme: "auto",
+  plugins: [
+    imagePlugin(),
+    videoPlugin(),
+    audioPlugin(),
+    textPlugin(),
+    pdfPlugin({ workerSrc: pdfWorkerSrc }),
+    officePlugin(),
+    archivePlugin(),
+    emailPlugin(),
+    drawingPlugin(),
+    cadPlugin(),
+    model3dPlugin(),
+    gisPlugin(),
+    fallbackPlugin()
+  ]
+});
+
+viewer.resize();
+viewer.destroy();
+```
+
+### React
+
+```tsx
+import { FileViewer } from "@open-file-viewer/react";
+import { imagePlugin, pdfPlugin, officePlugin, textPlugin } from "@open-file-viewer/core";
+import "@open-file-viewer/core/style.css";
+import pdfWorkerSrc from "pdfjs-dist/build/pdf.worker.mjs?url";
+
+const plugins = [
+  imagePlugin(),
+  textPlugin(),
+  pdfPlugin({ workerSrc: pdfWorkerSrc }),
+  officePlugin()
+];
+
+export function AttachmentPreview({ file }: { file: File }) {
+  return (
+    <FileViewer
+      file={file}
+      fileName={file.name}
+      width="100%"
+      height="640px"
+      fit="contain"
+      toolbar
+      theme="auto"
+      plugins={plugins}
+    />
+  );
+}
+```
+
+### Vue
+
+```vue
+<script setup lang="ts">
+import { OpenFileViewer } from "@open-file-viewer/vue";
+import { imagePlugin, pdfPlugin, officePlugin, textPlugin } from "@open-file-viewer/core";
+import "@open-file-viewer/core/style.css";
+import pdfWorkerSrc from "pdfjs-dist/build/pdf.worker.mjs?url";
+
+defineProps<{ file: File }>();
+
+const plugins = [
+  imagePlugin(),
+  textPlugin(),
+  pdfPlugin({ workerSrc: pdfWorkerSrc }),
+  officePlugin()
+];
+</script>
+
+<template>
+  <OpenFileViewer
+    :file="file"
+    :file-name="file.name"
+    width="100%"
+    height="640px"
+    fit="contain"
+    toolbar
+    theme="auto"
+    :plugins="plugins"
+  />
+</template>
+```
+
+### Svelte
+
+```svelte
+<script lang="ts">
+  import { OpenFileViewer } from "@open-file-viewer/svelte";
+  import { imagePlugin, pdfPlugin, officePlugin, textPlugin } from "@open-file-viewer/core";
+  import "@open-file-viewer/core/style.css";
+  import pdfWorkerSrc from "pdfjs-dist/build/pdf.worker.mjs?url";
+
+  export let file: File;
+
+  const plugins = [
+    imagePlugin(),
+    textPlugin(),
+    pdfPlugin({ workerSrc: pdfWorkerSrc }),
+    officePlugin()
+  ];
+</script>
+
+<OpenFileViewer
+  {file}
+  fileName={file.name}
+  width="100%"
+  height="640px"
+  fit="contain"
+  toolbar
+  theme="auto"
+  {plugins}
+/>
+```
+
+## 利用シーン
+
+| シーン | Open File Viewer が提供するもの |
+| --- | --- |
+| OA / ERP / CRM の添付ファイルセンター | 契約書、表計算、画像、メール、アーカイブを統一コンテナでプレビュー |
+| クラウドドライブ / ナレッジベース / 文書システム | 複数ファイルキュー、ダウンロード、検索、全画面、テーマ適応 |
+| ローコード / フォームシステム | React、Vue、Svelte を強制しない Vanilla JS 統合 |
+| エンジニアリング / 製造 / GIS システム | CAD、3D、GIS、図面系ファイルの認識と段階的強化 |
+| 開発者プラットフォーム / ログプラットフォーム | テキスト、設定、Markdown、コードハイライト、大容量ファイル保護 |
+
+## 機能概要
+
+| 機能 | 状態 |
+| --- | --- |
+| Vanilla JS / React / Vue / Svelte 統合 | 対応済み |
+| カスタムコンテナ、幅、高さ、レスポンシブサイズ | 対応済み |
+| 複数ファイルキュー、切り替え、現在インデックス | 対応済み |
+| ツールバー、ダウンロード、全画面、印刷、検索 | 対応済み |
+| light、dark、`auto` テーマ | 対応済み |
+| ローカル `File` / `Blob` / URL / `ArrayBuffer` 入力 | 対応済み |
+| プラグインプロトコルとカスタム fallback | 対応済み |
+| PDF、画像、音声・動画、テキスト/コード | 対応済み |
+| Office、OFD、EPUB、XPS、メール、アーカイブ | 基本から拡張プレビューまで |
+| CAD、3D、GIS、描画ボード、デザイン資産 | 認識、基本プレビュー、継続的な強化 |
+
+## 形式カバレッジ
+
+| カテゴリ | プラグイン | 代表的な形式 |
+| --- | --- | --- |
+| 画像 | `imagePlugin()` | `jpg`, `png`, `gif`, `webp`, `avif`, `svg`, `bmp`, `tiff`, `heic`, `heif` |
+| 動画 | `videoPlugin()` | `mp4`, `webm`, `mov`, `m4v`, `avi`, `mkv`, `flv`, `wmv`, `m3u8`, `m2ts` |
+| 音声 | `audioPlugin()` | `mp3`, `wav`, `ogg`, `aac`, `m4a`, `flac`, `opus`, `mid`, `wma` |
+| テキスト / コード | `textPlugin()` | `txt`, `md`, `json`, `yaml`, `xml`, `csv`, `js`, `ts`, `tsx`, `vue`, `html`, `css`, `py`, `go`, `rs`, `sql`, `sh` |
+| PDF / 電子書籍 | `pdfPlugin()`, `epubPlugin()`, `xpsPlugin()` | `pdf`, `epub`, `xps`, `oxps` |
+| Office | `officePlugin()` | `docx`, `rtf`, `odt`, `xlsx`, `csv`, `pptx`, `odp`, `wps`, `et`, `dps` |
+| OFD | `ofdPlugin()` | `ofd` |
+| アーカイブ | `archivePlugin()` | `zip`, `rar`, `7z`, `tar`, `gz`, `tgz`, `bz2`, `xz` |
+| メール | `emailPlugin()` | `eml`, `msg`, `mbox` |
+| 描画 / ホワイトボード | `drawingPlugin()` | `drawio`, `dio`, `excalidraw`, `tldraw` |
+| CAD / エンジニアリング | `cadPlugin()` | `dxf`, `dwg`, `dwf`, `step`, `stp`, `iges`, `igs`, `ifc`, `skp`, `sldprt` |
+| 3D モデル | `model3dPlugin()` | `gltf`, `glb`, `obj`, `stl`, `fbx`, `dae`, `ply`, `3mf`, `usd`, `usdz` |
+| GIS | `gisPlugin()` | `geojson`, `topojson`, `kml`, `kmz`, `gpx`, `shp` |
+| アセット認識 | `assetPlugin()` | `ttf`, `woff2`, `psd`, `ai`, `eps`, `sqlite`, `wasm`, `parquet`, `avro` |
+
+複雑な形式のプレビュー品質は、ブラウザの能力、ファイル構造、各プラグインで使用するパーサーに依存します。現在のバージョンは、すべての形式をコンテナ内の制御可能なプレビュー経路に入れることを優先しています。高忠実度の Office、CAD、デザイン、専有バイナリ形式は、専用エンジンやサーバーサイド変換で継続的に強化できます。
+
+プラグインの順序は重要です。最初に一致したプラグインがファイルをレンダリングします。たとえば `csv` と `tsv` は `textPlugin()` と `officePlugin()` の両方に一致するため、表計算形式のテーブルプレビューを優先したい場合は `officePlugin()` を前に配置してください。
+
+## Core API
+
+```ts
+createViewer(options: PreviewOptions): FileViewer;
+```
+
+### PreviewOptions
+
+| オプション | 型 | デフォルト | 説明 |
+| --- | --- | --- | --- |
+| `container` | `HTMLElement \| string` | 必須 | プレビューコンテナ |
+| `file` | `File \| Blob \| string \| ArrayBuffer` | - | 単一ファイルのプレビューソース |
+| `files` | `(PreviewSource \| PreviewItem)[]` | - | 複数ファイルのプレビューキュー |
+| `initialIndex` | `number` | `0` | 初期ファイルインデックス |
+| `fileName` | `string` | 自動推論 | 拡張子検出に使うファイル名 |
+| `mimeType` | `string` | 自動推論 | MIME タイプ |
+| `width` | `number \| string` | 元のコンテナ幅 | プレビューコンテナの幅 |
+| `height` | `number \| string` | 元のコンテナ高さ | プレビューコンテナの高さ |
+| `fit` | `contain \| cover \| width \| height \| actual \| scale-down` | `contain` | コンテンツのフィット方式 |
+| `plugins` | `PreviewPlugin[]` | `[]` | 順番にマッチするプラグインリスト |
+| `fallback` | `inline \| download \| custom` | `inline` | 非対応形式の fallback 戦略 |
+| `renderFallback` | `(ctx) => PreviewInstance` | - | カスタム fallback レンダラー |
+| `toolbar` | `boolean \| PreviewToolbarOptions` | `false` | ツールバー設定 |
+| `theme` | `light \| dark \| auto` | `light` | ビューアテーマ |
+| `className` | `string` | - | 追加コンテナクラス名 |
+| `onLoad` | `(file) => void` | - | 読み込み完了コールバック |
+| `onError` | `(error, file) => void` | - | エラーコールバック |
+| `onUnsupported` | `(file) => void` | - | 非対応形式コールバック |
+
+## ツールバーのカスタマイズ
+
+`toolbar: true` は、アクティブなプラグインが対応している場合に、複数ファイルナビゲーション、ズーム、回転、ダウンロード、全画面、印刷、検索を含むデフォルトツールバーを有効にします。業務フローに合わせて、ビューア全体を書き直さずに拡張できます。
+
+### ラベル、順序、アイコンのカスタマイズ
+
+```ts
+createViewer({
+  container: "#viewer",
+  file,
+  toolbar: {
+    zoom: true,
+    rotate: true,
+    download: true,
+    fullscreen: true,
+    search: true,
+    labels: {
+      download: "Download",
+      fullscreen: "Fullscreen",
+      search: "Search",
+      "zoom-in": "Zoom in",
+      "zoom-out": "Zoom out",
+      "zoom-reset": "Actual size",
+      "rotate-right": "Rotate"
+    },
+    titles: {
+      download: "Download current file"
+    },
+    icons: {
+      download: '<svg viewBox="0 0 24 24"><path d="M12 3v12m0 0 4-4m-4 4-4-4M5 21h14"/></svg>'
+    },
+    order: ["search", "zoom-out", "zoom-in", "zoom-reset", "rotate-right", "download", "fullscreen"]
+  },
+  plugins
+});
+```
+
+### 業務アクションの追加
+
+```ts
+createViewer({
+  container: "#viewer",
+  file,
+  toolbar: {
+    order: ["download", "favorite", "approve", "share", "fullscreen"],
+    actions: [
+      {
+        id: "favorite",
+        label: "Favorite",
+        onClick(ctx) {
+          favoriteFile(ctx.file);
+        }
+      },
+      {
+        id: "approve",
+        label: "Approve",
+        onClick(ctx) {
+          openApprovalDialog(ctx.file);
+        }
+      },
+      {
+        id: "share",
+        label: "Share",
+        disabled(ctx) {
+          return !ctx.file;
+        },
+        onClick(ctx) {
+          shareFile(ctx.file);
+        }
+      }
+    ]
+  },
+  plugins
+});
+```
+
+### ツールバーを完全に置き換える
+
+```ts
+createViewer({
+  container: "#viewer",
+  files,
+  toolbar: {
+    render(ctx) {
+      const bar = document.createElement("div");
+      bar.className = "business-toolbar";
+
+      const name = document.createElement("strong");
+      name.textContent = ctx.file?.name || "";
+
+      const next = document.createElement("button");
+      next.type = "button";
+      next.textContent = "Next";
+      next.disabled = !ctx.canNext;
+      next.onclick = () => void ctx.next();
+
+      const download = document.createElement("button");
+      download.type = "button";
+      download.textContent = "Download";
+      download.onclick = ctx.download;
+
+      bar.append(name, next, download);
+      return bar;
+    }
+  },
+  plugins
+});
+```
+
+`render(ctx)` のコンテキストには、`file`、`index`、`length`、`previous()`、`next()`、`command()`、`download()`、`fullscreen()`、`print()`、`search()`、`clearSearch()` が含まれます。core では `toolbar.render(ctx)` は DOM の `HTMLElement | void` を返します。React、Vue、Svelte では、それぞれのフレームワークに合ったツールバー API が提供されます。
+
+### React カスタムツールバー
+
+```tsx
+<FileViewer
+  files={files}
+  plugins={plugins}
+  renderToolbar={(ctx) => (
+    <>
+      <button disabled={!ctx.canPrevious} onClick={() => void ctx.previous()}>Previous</button>
+      <span>{ctx.index + 1} / {ctx.length}</span>
+      <button disabled={!ctx.canNext} onClick={() => void ctx.next()}>Next</button>
+      <button onClick={ctx.download}>Download</button>
+      <button onClick={() => openApprovalDialog(ctx.file)}>Approve</button>
+    </>
+  )}
+/>
+```
+
+### Vue カスタムツールバー
+
+```vue
+<OpenFileViewer :files="files" :plugins="plugins">
+  <template #toolbar="ctx">
+    <button :disabled="!ctx.canPrevious" @click="ctx.previous()">Previous</button>
+    <span>{{ ctx.index + 1 }} / {{ ctx.length }}</span>
+    <button :disabled="!ctx.canNext" @click="ctx.next()">Next</button>
+    <button @click="ctx.download()">Download</button>
+    <button @click="openApprovalDialog(ctx.file)">Approve</button>
+  </template>
+</OpenFileViewer>
+```
+
+### Svelte カスタムツールバー
+
+```svelte
+<OpenFileViewer files={files} plugins={plugins}>
+  <svelte:fragment slot="toolbar" let:ctx>
+    {#if ctx}
+      <button disabled={!ctx.canPrevious} on:click={() => void ctx.previous()}>Previous</button>
+      <span>{ctx.index + 1} / {ctx.length}</span>
+      <button disabled={!ctx.canNext} on:click={() => void ctx.next()}>Next</button>
+      <button on:click={ctx.download}>Download</button>
+      <button on:click={() => openApprovalDialog(ctx.file)}>Approve</button>
+    {/if}
+  </svelte:fragment>
+</OpenFileViewer>
+```
+
+スタイル層では、`.ofv-toolbar`、`.ofv-toolbar button`、`.ofv-toolbar-search` などの class を引き続き上書きできます。カスタムアイコンボタンは `.ofv-toolbar-icon` と `.ofv-toolbar-label` も生成するため、配置、余白、省略表示を制御しやすくなります。
+
+### FileViewer
+
+| メソッド | 説明 |
+| --- | --- |
+| `reload(file?)` | 現在のファイルまたは指定ファイルを再読み込み |
+| `next()` / `previous()` | 複数ファイルキューを切り替え |
+| `goTo(index)` | 指定ファイルへ移動 |
+| `getCurrentIndex()` | 現在のインデックスを取得 |
+| `resize()` | サイズ再計算を手動で実行 |
+| `destroy()` | ビューアを破棄し、リソースを解放 |
+
+## プラグイン開発
+
+各形式はプラグインとして統合されます。プラグインが答える必要があるのは、このファイルが一致するか、そして `ctx.viewport` にどうレンダリングするか、という 2 点です。
+
+```ts
+import type { PreviewPlugin } from "@open-file-viewer/core";
+
+export function customPlugin(): PreviewPlugin {
+  return {
+    name: "custom",
+    match(file) {
+      return file.extension === "custom";
+    },
+    async render(ctx) {
+      const element = document.createElement("div");
+      element.textContent = ctx.file.name;
+      ctx.viewport.append(element);
+
+      return {
+        resize(size) {
+          console.log("container resized", size);
+        },
+        destroy() {
+          element.remove();
+        }
+      };
+    }
+  };
+}
+```
+
+プラグインの制約:
+
+- `ctx.viewport` の中だけにレンダリングする。
+- デフォルトでは新しいウィンドウを開かない。
+- コンテナサイズの変化に反応する必要がある場合は `resize(size)` を実装する。
+- イベント、Object URL、タイマー、Canvas/WebGL リソースなどの副作用を解放するために `destroy()` を実装する。
+
+## パッケージ構成
+
+```txt
+packages/
+  core/      # フレームワーク非依存のプレビュー core とプラグイン
+  react/     # React アダプター
+  vue/       # Vue アダプター
+  svelte/    # Svelte アダプター
+examples/
+  vanilla/   # Vanilla JavaScript の例
+  react/     # React の例
+  vue/       # Vue の例
+  svelte/    # Svelte の例
+doc/         # Web サイトとオンライン体験
+```
+
+## ローカル開発
+
+```bash
+pnpm install
+pnpm check
+```
+
+よく使うコマンド:
+
+```bash
+pnpm dev:doc
+pnpm dev:vanilla
+pnpm dev:react
+pnpm dev:vue
+pnpm dev:svelte
+pnpm test
+pnpm typecheck
+pnpm build
+pnpm build:examples
+pnpm build:doc
+pnpm pack:check
+```
+
+`pnpm check` は、テスト、型チェック、packages ビルド、examples ビルド、Web サイトビルド、package exports 検証を順番に実行します。
+
+## ロードマップ
+
+| バージョン | フォーカス |
+| --- | --- |
+| `0.1.x` | Core プラグインシステム、コンテナ内プレビュー、React/Vue/Svelte/Vanilla 統合、基本的な複数形式プレビュー |
+| `0.2.x` | ツールバー、テーマ、画像操作、PDF 検索、統一状態、fallback |
+| `0.3.x` | Markdown/コードリーダー、Office 表計算と文書体験の強化 |
+| `0.4.x` | OFD、メール、アーカイブ、描画ファイル、中国国内業務で頻出する形式の強化 |
+| `0.5.x` | CAD、3D、GIS、専用パーサー、サーバーサイド変換との連携 |
+| `1.0.0` | 安定 API、完全なドキュメントサイト、ビジュアル回帰テスト、プラグイン開発ガイド |
+
+## コミュニティとサポート
+
+Open File Viewer は、より多くの形式プレビュー、フレームワーク統合、実際の業務シーンを継続的に改善します。オープンソースの継続は簡単ではありません。開発時間の節約に役立った場合は、無料の GitHub Star が今後の改善を支える大きな助けになります。
+
+- フィードバック: GitHub Issues、コミュニティグループ、作者の WeChat を通じて、ファイルサンプル、レイアウト問題、コンテナ適応問題、新しい形式の要望を共有してください。
+- 学習と交流: 公式アカウント "Frontend Development Enthusiasts" では、フロントエンドエンジニアリング、コンポーネント開発、オープンソース実践を継続的に共有します。
+- 作者のサポート: 作者にコーヒーやミネラルウォーターをごちそうしたい場合、その応援はとても励みになります。寄付ユーザーは作者の WeChat を追加して、今後フロントエンド関連の話題を交流できます。
+
+<table>
+  <tr>
+    <td align="center" width="20%">
+      <img src="./doc/public/images/official-account-qr.jpg" width="140" alt="Official account QR code: Frontend Development Enthusiasts" />
+      <br />
+      <strong>Official Account</strong>
+      <br />
+      Frontend Development Enthusiasts
+    </td>
+    <td align="center" width="20%">
+      <img src="./doc/public/images/community-group-qr.png" width="140" alt="Community group QR code" />
+      <br />
+      <strong>Community Group</strong>
+      <br />
+      Frontend technology discussion
+    </td>
+    <td align="center" width="20%">
+      <img src="./doc/public/images/author-wechat-qr.png" width="140" alt="Author WeChat QR code" />
+      <br />
+      <strong>Author WeChat</strong>
+      <br />
+      Frontend discussion
+    </td>
+    <td align="center" width="20%">
+      <img src="./doc/public/images/wechat-donation-qr.png" width="140" alt="WeChat donation QR code" />
+      <br />
+      <strong>WeChat Donation</strong>
+      <br />
+      Buy the author a coffee
+    </td>
+    <td align="center" width="20%">
+      <img src="./doc/public/images/alipay-donation-qr.png" width="140" alt="Alipay donation QR code" />
+      <br />
+      <strong>Alipay Donation</strong>
+      <br />
+      Buy the author a bottle of water
+    </td>
+  </tr>
+</table>
+
+## リンク
+
+- Web サイト: https://open-file-viewer-workspace.void.app
+- About: https://open-file-viewer-workspace.void.app/about.html
+- GitHub: https://github.com/xushanpei/open-file-viewer
+- NPM Core: https://www.npmjs.com/package/@open-file-viewer/core
+- NPM React: https://www.npmjs.com/package/@open-file-viewer/react
+- NPM Vue: https://www.npmjs.com/package/@open-file-viewer/vue
+- NPM Svelte: https://www.npmjs.com/package/@open-file-viewer/svelte
+
+## License
+
+[MIT](./LICENSE)

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,0 +1,644 @@
+# Open File Viewer
+
+<p align="right">
+  <a href="./README.md">简体中文</a>
+  |
+  <a href="./README.en.md">English</a>
+  |
+  <a href="./README.ja.md">日本語</a>
+  |
+  <strong>한국어</strong>
+  |
+  <a href="./README.es.md">Español</a>
+  |
+  <a href="./README.pt-BR.md">Português</a>
+</p>
+
+Open File Viewer는 현대적인 Web 제품을 위한 파일 미리보기 SDK입니다. PDF, Office 문서, 이미지, 오디오/비디오, 압축 파일, 이메일, 도면, 3D 파일, GIS 데이터, 소스 코드를 하나의 제어 가능한 컨테이너 안에서 다룰 수 있으며 Vanilla JavaScript, React, Vue, Svelte를 지원합니다.
+
+<p>
+  <a href="https://open-file-viewer-workspace.void.app">웹사이트</a>
+  |
+  <a href="https://open-file-viewer-workspace.void.app/about.html">About</a>
+  |
+  <a href="https://github.com/xushanpei/open-file-viewer">GitHub</a>
+  |
+  <a href="https://www.npmjs.com/package/@open-file-viewer/core">NPM Core</a>
+  |
+  <a href="https://www.npmjs.com/package/@open-file-viewer/react">React</a>
+  |
+  <a href="https://www.npmjs.com/package/@open-file-viewer/vue">Vue</a>
+  |
+  <a href="https://www.npmjs.com/package/@open-file-viewer/svelte">Svelte</a>
+</p>
+
+[![GitHub](https://img.shields.io/badge/GitHub-xushanpei%2Fopen--file--viewer-111827?logo=github)](https://github.com/xushanpei/open-file-viewer)
+[![Core](https://img.shields.io/npm/v/@open-file-viewer/core?label=%40open-file-viewer%2Fcore&color=7c5cff)](https://www.npmjs.com/package/@open-file-viewer/core)
+[![React](https://img.shields.io/npm/v/@open-file-viewer/react?label=react&color=149eca)](https://www.npmjs.com/package/@open-file-viewer/react)
+[![Vue](https://img.shields.io/npm/v/@open-file-viewer/vue?label=vue&color=41b883)](https://www.npmjs.com/package/@open-file-viewer/vue)
+[![Svelte](https://img.shields.io/npm/v/@open-file-viewer/svelte?label=svelte&color=ff3e00)](https://www.npmjs.com/package/@open-file-viewer/svelte)
+[![License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
+
+## 선택 이유
+
+대부분의 업무 시스템은 언젠가 첨부 파일 미리보기를 필요로 합니다. 계약서, 스프레드시트, 도면, 압축 파일, 이메일, 이미지, 비디오, 소스 파일이 모두 그 대상입니다. Open File Viewer는 PDF만 여는 데모가 아니라 실제 제품 요구에 맞춰 장기적으로 발전할 수 있는 파일 미리보기 기반입니다.
+
+- **컨테이너 우선**: 모든 콘텐츠는 사용자가 전달한 DOM 컨테이너 안에 렌더링됩니다. 새 창을 열지 않고 업무 페이지의 흐름을 방해하지 않습니다.
+- **여러 프레임워크 지원**: Vanilla JavaScript, React, Vue, Svelte가 동일한 core 기능을 공유합니다.
+- **플러그인 기반 형식 처리**: 각 파일 형식은 독립 플러그인이 담당하므로 교체, 축소, 확장이 쉽습니다.
+- **반응형 미리보기**: `px`, `%`, `vh`, `vw`, `rem`, `calc()` 같은 CSS 크기를 지원하고 컨테이너 변화에 자동으로 반응합니다.
+- **애플리케이션용 기본 상태**: loading, error, unsupported, download fallback, toolbar, theme, multi-file queue를 제공합니다.
+- **복잡한 형식의 점진적 강화**: 브라우저가 직접 미리볼 수 있는 형식은 우선 로컬에서 렌더링하고, 복잡한 형식은 WASM, 전용 파서, 서버 사이드 변환으로 단계적으로 강화할 수 있습니다.
+
+## 설치
+
+```bash
+pnpm add @open-file-viewer/core
+```
+
+React:
+
+```bash
+pnpm add @open-file-viewer/core @open-file-viewer/react
+```
+
+Vue:
+
+```bash
+pnpm add @open-file-viewer/core @open-file-viewer/vue
+```
+
+Svelte:
+
+```bash
+pnpm add @open-file-viewer/core @open-file-viewer/svelte
+```
+
+`pdfPlugin()`을 사용할 때 PDF 미리보기에는 `pdfjs-dist`가 필요합니다.
+
+```bash
+pnpm add pdfjs-dist
+```
+
+npm 또는 yarn도 사용할 수 있습니다.
+
+```bash
+npm install @open-file-viewer/core
+yarn add @open-file-viewer/core
+```
+
+공유 스타일은 애플리케이션에서 한 번 import 하세요.
+
+```ts
+import "@open-file-viewer/core/style.css";
+```
+
+## 빠른 시작
+
+### Vanilla JavaScript
+
+```ts
+import {
+  createViewer,
+  imagePlugin,
+  videoPlugin,
+  audioPlugin,
+  textPlugin,
+  pdfPlugin,
+  officePlugin,
+  archivePlugin,
+  emailPlugin,
+  drawingPlugin,
+  cadPlugin,
+  model3dPlugin,
+  gisPlugin,
+  fallbackPlugin
+} from "@open-file-viewer/core";
+import "@open-file-viewer/core/style.css";
+import pdfWorkerSrc from "pdfjs-dist/build/pdf.worker.mjs?url";
+
+const viewer = createViewer({
+  container: "#viewer",
+  file: fileOrUrl,
+  fileName: "contract.pdf",
+  width: "100%",
+  height: "70vh",
+  fit: "contain",
+  toolbar: true,
+  theme: "auto",
+  plugins: [
+    imagePlugin(),
+    videoPlugin(),
+    audioPlugin(),
+    textPlugin(),
+    pdfPlugin({ workerSrc: pdfWorkerSrc }),
+    officePlugin(),
+    archivePlugin(),
+    emailPlugin(),
+    drawingPlugin(),
+    cadPlugin(),
+    model3dPlugin(),
+    gisPlugin(),
+    fallbackPlugin()
+  ]
+});
+
+viewer.resize();
+viewer.destroy();
+```
+
+### React
+
+```tsx
+import { FileViewer } from "@open-file-viewer/react";
+import { imagePlugin, pdfPlugin, officePlugin, textPlugin } from "@open-file-viewer/core";
+import "@open-file-viewer/core/style.css";
+import pdfWorkerSrc from "pdfjs-dist/build/pdf.worker.mjs?url";
+
+const plugins = [
+  imagePlugin(),
+  textPlugin(),
+  pdfPlugin({ workerSrc: pdfWorkerSrc }),
+  officePlugin()
+];
+
+export function AttachmentPreview({ file }: { file: File }) {
+  return (
+    <FileViewer
+      file={file}
+      fileName={file.name}
+      width="100%"
+      height="640px"
+      fit="contain"
+      toolbar
+      theme="auto"
+      plugins={plugins}
+    />
+  );
+}
+```
+
+### Vue
+
+```vue
+<script setup lang="ts">
+import { OpenFileViewer } from "@open-file-viewer/vue";
+import { imagePlugin, pdfPlugin, officePlugin, textPlugin } from "@open-file-viewer/core";
+import "@open-file-viewer/core/style.css";
+import pdfWorkerSrc from "pdfjs-dist/build/pdf.worker.mjs?url";
+
+defineProps<{ file: File }>();
+
+const plugins = [
+  imagePlugin(),
+  textPlugin(),
+  pdfPlugin({ workerSrc: pdfWorkerSrc }),
+  officePlugin()
+];
+</script>
+
+<template>
+  <OpenFileViewer
+    :file="file"
+    :file-name="file.name"
+    width="100%"
+    height="640px"
+    fit="contain"
+    toolbar
+    theme="auto"
+    :plugins="plugins"
+  />
+</template>
+```
+
+### Svelte
+
+```svelte
+<script lang="ts">
+  import { OpenFileViewer } from "@open-file-viewer/svelte";
+  import { imagePlugin, pdfPlugin, officePlugin, textPlugin } from "@open-file-viewer/core";
+  import "@open-file-viewer/core/style.css";
+  import pdfWorkerSrc from "pdfjs-dist/build/pdf.worker.mjs?url";
+
+  export let file: File;
+
+  const plugins = [
+    imagePlugin(),
+    textPlugin(),
+    pdfPlugin({ workerSrc: pdfWorkerSrc }),
+    officePlugin()
+  ];
+</script>
+
+<OpenFileViewer
+  {file}
+  fileName={file.name}
+  width="100%"
+  height="640px"
+  fit="contain"
+  toolbar
+  theme="auto"
+  {plugins}
+/>
+```
+
+## 사용 사례
+
+| 시나리오 | Open File Viewer가 제공하는 것 |
+| --- | --- |
+| OA / ERP / CRM 첨부 파일 센터 | 계약서, 스프레드시트, 이미지, 이메일, 압축 파일을 하나의 컨테이너에서 미리보기 |
+| 클라우드 드라이브 / 지식 베이스 / 문서 시스템 | 다중 파일 큐, 다운로드, 검색, 전체 화면, 테마 적응 |
+| 로우코드 / 폼 시스템 | React, Vue, Svelte에 강하게 의존하지 않는 Vanilla JS 통합 |
+| 엔지니어링 / 제조 / GIS 시스템 | CAD, 3D, GIS, 도면 파일 인식과 점진적 강화 |
+| 개발자 플랫폼 / 로그 플랫폼 | 텍스트, 설정, Markdown, 코드 하이라이트, 대용량 파일 보호 |
+
+## 기능 개요
+
+| 기능 | 상태 |
+| --- | --- |
+| Vanilla JS / React / Vue / Svelte 통합 | 지원 |
+| 사용자 지정 컨테이너, 너비, 높이, 반응형 크기 | 지원 |
+| 다중 파일 큐, 전환, 현재 인덱스 | 지원 |
+| 툴바, 다운로드, 전체 화면, 인쇄, 검색 | 지원 |
+| light, dark, `auto` 테마 | 지원 |
+| 로컬 `File` / `Blob` / URL / `ArrayBuffer` 입력 | 지원 |
+| 플러그인 프로토콜과 사용자 지정 fallback | 지원 |
+| PDF, 이미지, 오디오/비디오, 텍스트/코드 | 지원 |
+| Office, OFD, EPUB, XPS, 이메일, 압축 파일 | 기본에서 향상된 미리보기까지 |
+| CAD, 3D, GIS, 드로잉 보드, 디자인 자산 | 인식, 기본 미리보기, 지속적인 개선 |
+
+## 형식 지원
+
+| 분류 | 플러그인 | 대표 형식 |
+| --- | --- | --- |
+| 이미지 | `imagePlugin()` | `jpg`, `png`, `gif`, `webp`, `avif`, `svg`, `bmp`, `tiff`, `heic`, `heif` |
+| 비디오 | `videoPlugin()` | `mp4`, `webm`, `mov`, `m4v`, `avi`, `mkv`, `flv`, `wmv`, `m3u8`, `m2ts` |
+| 오디오 | `audioPlugin()` | `mp3`, `wav`, `ogg`, `aac`, `m4a`, `flac`, `opus`, `mid`, `wma` |
+| 텍스트 / 코드 | `textPlugin()` | `txt`, `md`, `json`, `yaml`, `xml`, `csv`, `js`, `ts`, `tsx`, `vue`, `html`, `css`, `py`, `go`, `rs`, `sql`, `sh` |
+| PDF / 전자책 | `pdfPlugin()`, `epubPlugin()`, `xpsPlugin()` | `pdf`, `epub`, `xps`, `oxps` |
+| Office | `officePlugin()` | `docx`, `rtf`, `odt`, `xlsx`, `csv`, `pptx`, `odp`, `wps`, `et`, `dps` |
+| OFD | `ofdPlugin()` | `ofd` |
+| 압축 파일 | `archivePlugin()` | `zip`, `rar`, `7z`, `tar`, `gz`, `tgz`, `bz2`, `xz` |
+| 이메일 | `emailPlugin()` | `eml`, `msg`, `mbox` |
+| 드로잉 / 화이트보드 | `drawingPlugin()` | `drawio`, `dio`, `excalidraw`, `tldraw` |
+| CAD / 엔지니어링 | `cadPlugin()` | `dxf`, `dwg`, `dwf`, `step`, `stp`, `iges`, `igs`, `ifc`, `skp`, `sldprt` |
+| 3D 모델 | `model3dPlugin()` | `gltf`, `glb`, `obj`, `stl`, `fbx`, `dae`, `ply`, `3mf`, `usd`, `usdz` |
+| GIS | `gisPlugin()` | `geojson`, `topojson`, `kml`, `kmz`, `gpx`, `shp` |
+| 자산 인식 | `assetPlugin()` | `ttf`, `woff2`, `psd`, `ai`, `eps`, `sqlite`, `wasm`, `parquet`, `avro` |
+
+복잡한 형식의 미리보기 품질은 브라우저 기능, 파일 구조, 각 플러그인이 사용하는 파서에 따라 달라집니다. 현재 버전은 모든 형식이 컨테이너 안에서 제어 가능한 미리보기 경로로 들어가도록 하는 데 우선순위를 둡니다. 고충실도 Office, CAD, 디자인, 전용 바이너리 형식은 전용 엔진이나 서버 사이드 변환으로 계속 강화할 수 있습니다.
+
+플러그인 순서는 중요합니다. 가장 먼저 일치한 플러그인이 파일을 렌더링합니다. 예를 들어 `csv`와 `tsv`는 `textPlugin()`과 `officePlugin()` 모두에 일치할 수 있으므로, 스프레드시트 스타일의 테이블 미리보기를 원한다면 `officePlugin()`을 앞에 배치하세요.
+
+## Core API
+
+```ts
+createViewer(options: PreviewOptions): FileViewer;
+```
+
+### PreviewOptions
+
+| 옵션 | 타입 | 기본값 | 설명 |
+| --- | --- | --- | --- |
+| `container` | `HTMLElement \| string` | 필수 | 미리보기 컨테이너 |
+| `file` | `File \| Blob \| string \| ArrayBuffer` | - | 단일 파일 미리보기 소스 |
+| `files` | `(PreviewSource \| PreviewItem)[]` | - | 다중 파일 미리보기 큐 |
+| `initialIndex` | `number` | `0` | 초기 파일 인덱스 |
+| `fileName` | `string` | 자동 추론 | 확장자 감지에 사용하는 파일명 |
+| `mimeType` | `string` | 자동 추론 | MIME 타입 |
+| `width` | `number \| string` | 원래 컨테이너 너비 | 미리보기 컨테이너 너비 |
+| `height` | `number \| string` | 원래 컨테이너 높이 | 미리보기 컨테이너 높이 |
+| `fit` | `contain \| cover \| width \| height \| actual \| scale-down` | `contain` | 콘텐츠 맞춤 방식 |
+| `plugins` | `PreviewPlugin[]` | `[]` | 순서대로 매칭되는 플러그인 목록 |
+| `fallback` | `inline \| download \| custom` | `inline` | 지원되지 않는 형식의 fallback 전략 |
+| `renderFallback` | `(ctx) => PreviewInstance` | - | 사용자 지정 fallback 렌더러 |
+| `toolbar` | `boolean \| PreviewToolbarOptions` | `false` | 툴바 설정 |
+| `theme` | `light \| dark \| auto` | `light` | 뷰어 테마 |
+| `className` | `string` | - | 추가 컨테이너 클래스명 |
+| `onLoad` | `(file) => void` | - | 로드 완료 콜백 |
+| `onError` | `(error, file) => void` | - | 오류 콜백 |
+| `onUnsupported` | `(file) => void` | - | 지원되지 않는 형식 콜백 |
+
+## 툴바 사용자 지정
+
+`toolbar: true`는 활성 플러그인이 지원하는 경우 다중 파일 탐색, 확대/축소, 회전, 다운로드, 전체 화면, 인쇄, 검색을 포함하는 기본 툴바를 활성화합니다. 전체 뷰어를 다시 작성하지 않고 업무 흐름에 맞게 확장할 수 있습니다.
+
+### 라벨, 순서, 아이콘 사용자 지정
+
+```ts
+createViewer({
+  container: "#viewer",
+  file,
+  toolbar: {
+    zoom: true,
+    rotate: true,
+    download: true,
+    fullscreen: true,
+    search: true,
+    labels: {
+      download: "Download",
+      fullscreen: "Fullscreen",
+      search: "Search",
+      "zoom-in": "Zoom in",
+      "zoom-out": "Zoom out",
+      "zoom-reset": "Actual size",
+      "rotate-right": "Rotate"
+    },
+    titles: {
+      download: "Download current file"
+    },
+    icons: {
+      download: '<svg viewBox="0 0 24 24"><path d="M12 3v12m0 0 4-4m-4 4-4-4M5 21h14"/></svg>'
+    },
+    order: ["search", "zoom-out", "zoom-in", "zoom-reset", "rotate-right", "download", "fullscreen"]
+  },
+  plugins
+});
+```
+
+### 업무 액션 추가
+
+```ts
+createViewer({
+  container: "#viewer",
+  file,
+  toolbar: {
+    order: ["download", "favorite", "approve", "share", "fullscreen"],
+    actions: [
+      {
+        id: "favorite",
+        label: "Favorite",
+        onClick(ctx) {
+          favoriteFile(ctx.file);
+        }
+      },
+      {
+        id: "approve",
+        label: "Approve",
+        onClick(ctx) {
+          openApprovalDialog(ctx.file);
+        }
+      },
+      {
+        id: "share",
+        label: "Share",
+        disabled(ctx) {
+          return !ctx.file;
+        },
+        onClick(ctx) {
+          shareFile(ctx.file);
+        }
+      }
+    ]
+  },
+  plugins
+});
+```
+
+### 툴바 완전 교체
+
+```ts
+createViewer({
+  container: "#viewer",
+  files,
+  toolbar: {
+    render(ctx) {
+      const bar = document.createElement("div");
+      bar.className = "business-toolbar";
+
+      const name = document.createElement("strong");
+      name.textContent = ctx.file?.name || "";
+
+      const next = document.createElement("button");
+      next.type = "button";
+      next.textContent = "Next";
+      next.disabled = !ctx.canNext;
+      next.onclick = () => void ctx.next();
+
+      const download = document.createElement("button");
+      download.type = "button";
+      download.textContent = "Download";
+      download.onclick = ctx.download;
+
+      bar.append(name, next, download);
+      return bar;
+    }
+  },
+  plugins
+});
+```
+
+`render(ctx)` 컨텍스트에는 `file`, `index`, `length`, `previous()`, `next()`, `command()`, `download()`, `fullscreen()`, `print()`, `search()`, `clearSearch()`가 포함됩니다. core에서 `toolbar.render(ctx)`는 DOM `HTMLElement | void`를 반환합니다. React, Vue, Svelte는 각 프레임워크에 맞는 툴바 API를 제공합니다.
+
+### React 사용자 지정 툴바
+
+```tsx
+<FileViewer
+  files={files}
+  plugins={plugins}
+  renderToolbar={(ctx) => (
+    <>
+      <button disabled={!ctx.canPrevious} onClick={() => void ctx.previous()}>Previous</button>
+      <span>{ctx.index + 1} / {ctx.length}</span>
+      <button disabled={!ctx.canNext} onClick={() => void ctx.next()}>Next</button>
+      <button onClick={ctx.download}>Download</button>
+      <button onClick={() => openApprovalDialog(ctx.file)}>Approve</button>
+    </>
+  )}
+/>
+```
+
+### Vue 사용자 지정 툴바
+
+```vue
+<OpenFileViewer :files="files" :plugins="plugins">
+  <template #toolbar="ctx">
+    <button :disabled="!ctx.canPrevious" @click="ctx.previous()">Previous</button>
+    <span>{{ ctx.index + 1 }} / {{ ctx.length }}</span>
+    <button :disabled="!ctx.canNext" @click="ctx.next()">Next</button>
+    <button @click="ctx.download()">Download</button>
+    <button @click="openApprovalDialog(ctx.file)">Approve</button>
+  </template>
+</OpenFileViewer>
+```
+
+### Svelte 사용자 지정 툴바
+
+```svelte
+<OpenFileViewer files={files} plugins={plugins}>
+  <svelte:fragment slot="toolbar" let:ctx>
+    {#if ctx}
+      <button disabled={!ctx.canPrevious} on:click={() => void ctx.previous()}>Previous</button>
+      <span>{ctx.index + 1} / {ctx.length}</span>
+      <button disabled={!ctx.canNext} on:click={() => void ctx.next()}>Next</button>
+      <button on:click={ctx.download}>Download</button>
+      <button on:click={() => openApprovalDialog(ctx.file)}>Approve</button>
+    {/if}
+  </svelte:fragment>
+</OpenFileViewer>
+```
+
+스타일 레이어에서는 `.ofv-toolbar`, `.ofv-toolbar button`, `.ofv-toolbar-search` 같은 class를 계속 오버라이드할 수 있습니다. 사용자 지정 아이콘 버튼은 `.ofv-toolbar-icon`과 `.ofv-toolbar-label`도 생성하므로 정렬, 간격, 말줄임을 제어하기 쉽습니다.
+
+### FileViewer
+
+| 메서드 | 설명 |
+| --- | --- |
+| `reload(file?)` | 현재 파일 또는 지정 파일 다시 로드 |
+| `next()` / `previous()` | 다중 파일 큐 전환 |
+| `goTo(index)` | 지정 파일로 이동 |
+| `getCurrentIndex()` | 현재 인덱스 가져오기 |
+| `resize()` | 크기 재계산을 수동으로 트리거 |
+| `destroy()` | 뷰어를 제거하고 리소스 정리 |
+
+## 플러그인 개발
+
+각 형식은 플러그인을 통해 통합됩니다. 플러그인은 이 파일이 매칭되는지, 그리고 `ctx.viewport`에 어떻게 렌더링할지만 결정하면 됩니다.
+
+```ts
+import type { PreviewPlugin } from "@open-file-viewer/core";
+
+export function customPlugin(): PreviewPlugin {
+  return {
+    name: "custom",
+    match(file) {
+      return file.extension === "custom";
+    },
+    async render(ctx) {
+      const element = document.createElement("div");
+      element.textContent = ctx.file.name;
+      ctx.viewport.append(element);
+
+      return {
+        resize(size) {
+          console.log("container resized", size);
+        },
+        destroy() {
+          element.remove();
+        }
+      };
+    }
+  };
+}
+```
+
+플러그인 제약:
+
+- `ctx.viewport` 안에만 렌더링합니다.
+- 기본적으로 새 창을 열지 않습니다.
+- 컨테이너 크기 변화에 대응해야 하면 `resize(size)`를 구현합니다.
+- 이벤트, Object URL, 타이머, Canvas/WebGL 리소스 같은 부작용을 정리하기 위해 `destroy()`를 구현합니다.
+
+## 패키지 구조
+
+```txt
+packages/
+  core/      # 프레임워크에 독립적인 미리보기 core와 플러그인
+  react/     # React 어댑터
+  vue/       # Vue 어댑터
+  svelte/    # Svelte 어댑터
+examples/
+  vanilla/   # Vanilla JavaScript 예제
+  react/     # React 예제
+  vue/       # Vue 예제
+  svelte/    # Svelte 예제
+doc/         # 웹사이트와 온라인 경험
+```
+
+## 로컬 개발
+
+```bash
+pnpm install
+pnpm check
+```
+
+자주 사용하는 명령:
+
+```bash
+pnpm dev:doc
+pnpm dev:vanilla
+pnpm dev:react
+pnpm dev:vue
+pnpm dev:svelte
+pnpm test
+pnpm typecheck
+pnpm build
+pnpm build:examples
+pnpm build:doc
+pnpm pack:check
+```
+
+`pnpm check`는 테스트, 타입 검사, packages 빌드, examples 빌드, 웹사이트 빌드, package exports 검증을 순서대로 실행합니다.
+
+## 로드맵
+
+| 버전 | 중점 |
+| --- | --- |
+| `0.1.x` | Core 플러그인 시스템, 컨테이너 내 미리보기, React/Vue/Svelte/Vanilla 통합, 기본 다중 형식 미리보기 |
+| `0.2.x` | 툴바, 테마, 이미지 상호작용, PDF 검색, 통합 상태, fallback |
+| `0.3.x` | Markdown/코드 리더, Office 스프레드시트와 문서 경험 강화 |
+| `0.4.x` | OFD, 이메일, 압축 파일, 드로잉 파일, 중국 업무에서 자주 쓰이는 형식 강화 |
+| `0.5.x` | CAD, 3D, GIS, 전용 파서, 서버 사이드 변환 협업 |
+| `1.0.0` | 안정적인 API, 완전한 문서 사이트, 시각적 회귀 테스트, 플러그인 개발 가이드 |
+
+## 커뮤니티와 지원
+
+Open File Viewer는 더 많은 형식 미리보기, 프레임워크 통합, 실제 업무 시나리오를 계속 개선합니다. 오픈소스를 유지하는 일은 쉽지 않습니다. 개발 시간을 절약해 주었다면 GitHub Star는 앞으로의 개선에 큰 도움이 됩니다.
+
+- 피드백: GitHub Issues, 커뮤니티 그룹, 작성자의 WeChat을 통해 파일 샘플, 레이아웃 문제, 컨테이너 적응 문제, 새로운 형식 요청을 공유해 주세요.
+- 학습과 교류: 공식 계정 "Frontend Development Enthusiasts"는 프론트엔드 엔지니어링, 컴포넌트 개발, 오픈소스 실천을 계속 공유합니다.
+- 작성자 지원: 작성자에게 커피나 생수를 사 주고 싶다면 큰 격려가 됩니다. 후원 사용자는 작성자의 WeChat을 추가해 이후 프론트엔드 관련 이야기를 나눌 수 있습니다.
+
+<table>
+  <tr>
+    <td align="center" width="20%">
+      <img src="./doc/public/images/official-account-qr.jpg" width="140" alt="Official account QR code: Frontend Development Enthusiasts" />
+      <br />
+      <strong>Official Account</strong>
+      <br />
+      Frontend Development Enthusiasts
+    </td>
+    <td align="center" width="20%">
+      <img src="./doc/public/images/community-group-qr.png" width="140" alt="Community group QR code" />
+      <br />
+      <strong>Community Group</strong>
+      <br />
+      Frontend technology discussion
+    </td>
+    <td align="center" width="20%">
+      <img src="./doc/public/images/author-wechat-qr.png" width="140" alt="Author WeChat QR code" />
+      <br />
+      <strong>Author WeChat</strong>
+      <br />
+      Frontend discussion
+    </td>
+    <td align="center" width="20%">
+      <img src="./doc/public/images/wechat-donation-qr.png" width="140" alt="WeChat donation QR code" />
+      <br />
+      <strong>WeChat Donation</strong>
+      <br />
+      Buy the author a coffee
+    </td>
+    <td align="center" width="20%">
+      <img src="./doc/public/images/alipay-donation-qr.png" width="140" alt="Alipay donation QR code" />
+      <br />
+      <strong>Alipay Donation</strong>
+      <br />
+      Buy the author a bottle of water
+    </td>
+  </tr>
+</table>
+
+## 링크
+
+- 웹사이트: https://open-file-viewer-workspace.void.app
+- About: https://open-file-viewer-workspace.void.app/about.html
+- GitHub: https://github.com/xushanpei/open-file-viewer
+- NPM Core: https://www.npmjs.com/package/@open-file-viewer/core
+- NPM React: https://www.npmjs.com/package/@open-file-viewer/react
+- NPM Vue: https://www.npmjs.com/package/@open-file-viewer/vue
+- NPM Svelte: https://www.npmjs.com/package/@open-file-viewer/svelte
+
+## License
+
+[MIT](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Open File Viewer
 
+<p align="right">
+  <strong>简体中文</strong>
+  ·
+  <a href="./README.en.md">English</a>
+</p>
+
 Open File Viewer 是一个面向现代 Web 产品的文件预览 SDK。它把 PDF、Office、图片、音视频、压缩包、邮件、图纸、3D、GIS 和代码文件放进同一个可控容器里，并同时支持原生 JavaScript、React、Vue 和 Svelte。
 
 <p>

--- a/README.md
+++ b/README.md
@@ -2,8 +2,16 @@
 
 <p align="right">
   <strong>简体中文</strong>
-  ·
+  |
   <a href="./README.en.md">English</a>
+  |
+  <a href="./README.ja.md">日本語</a>
+  |
+  <a href="./README.ko.md">한국어</a>
+  |
+  <a href="./README.es.md">Español</a>
+  |
+  <a href="./README.pt-BR.md">Português</a>
 </p>
 
 Open File Viewer 是一个面向现代 Web 产品的文件预览 SDK。它把 PDF、Office、图片、音视频、压缩包、邮件、图纸、3D、GIS 和代码文件放进同一个可控容器里，并同时支持原生 JavaScript、React、Vue 和 Svelte。

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,9 +1,9 @@
 # Open File Viewer
 
 <p align="right">
-  <a href="./README.md">Simplified Chinese</a>
+  <a href="./README.md">简体中文</a>
   |
-  <strong>English</strong>
+  <a href="./README.en.md">English</a>
   |
   <a href="./README.ja.md">日本語</a>
   |
@@ -11,15 +11,15 @@
   |
   <a href="./README.es.md">Español</a>
   |
-  <a href="./README.pt-BR.md">Português</a>
+  <strong>Português</strong>
 </p>
 
-Open File Viewer is a file preview SDK for modern web applications. It brings PDFs, Office documents, images, audio and video, archives, emails, drawings, 3D files, GIS data, and source code into one controlled container, with support for vanilla JavaScript, React, Vue, and Svelte.
+Open File Viewer é um SDK de visualização de arquivos para aplicações web modernas. Ele coloca PDFs, documentos Office, imagens, áudio e vídeo, arquivos compactados, emails, desenhos, arquivos 3D, dados GIS e código-fonte dentro de um único contêiner controlado, com suporte a JavaScript nativo, React, Vue e Svelte.
 
 <p>
-  <a href="https://open-file-viewer-workspace.void.app">Website</a>
+  <a href="https://open-file-viewer-workspace.void.app">Site</a>
   |
-  <a href="https://open-file-viewer-workspace.void.app/about.html">About</a>
+  <a href="https://open-file-viewer-workspace.void.app/about.html">Sobre</a>
   |
   <a href="https://github.com/xushanpei/open-file-viewer">GitHub</a>
   |
@@ -39,18 +39,18 @@ Open File Viewer is a file preview SDK for modern web applications. It brings PD
 [![Svelte](https://img.shields.io/npm/v/@open-file-viewer/svelte?label=svelte&color=ff3e00)](https://www.npmjs.com/package/@open-file-viewer/svelte)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](./LICENSE)
 
-## Why Choose It
+## Por Que Escolher
 
-Most business systems eventually need attachment preview: contracts, spreadsheets, drawings, archives, emails, images, videos, and source files. Open File Viewer is not a PDF-only demo. It is a file preview foundation that can evolve with real product needs over time.
+A maioria dos sistemas de negócio acaba precisando visualizar anexos: contratos, planilhas, desenhos, arquivos compactados, emails, imagens, vídeos e arquivos de código. Open File Viewer não é uma demonstração apenas para PDF; é uma base de visualização de arquivos que pode evoluir com necessidades reais de produto.
 
-- **Container-first**: all content renders inside the DOM container you provide. It does not open a new window or interrupt the host business page.
-- **Multi-framework compatibility**: vanilla JavaScript, React, Vue, and Svelte share the same core capabilities.
-- **Plugin-based formats**: each file format is handled by an independent plugin, making behavior easier to replace, trim, and extend.
-- **Responsive preview**: supports CSS sizes such as `px`, `%`, `vh`, `vw`, `rem`, and `calc()`, and responds automatically to container changes.
-- **Application-ready states**: includes loading, error, unsupported, download fallback, toolbar, theme, and multi-file queue behavior.
-- **Progressive enhancement for complex formats**: formats that browsers can preview directly are rendered locally first; complex formats can gradually integrate WASM, dedicated parsers, or server-side conversion.
+- **Contêiner em primeiro lugar**: todo o conteúdo é renderizado dentro do contêiner DOM que você fornece. Ele não abre uma nova janela nem interrompe a página de negócio.
+- **Compatibilidade com vários frameworks**: JavaScript nativo, React, Vue e Svelte compartilham as mesmas capacidades do core.
+- **Formatos baseados em plugins**: cada formato de arquivo é tratado por um plugin independente, facilitando substituição, recorte e extensão.
+- **Visualização responsiva**: suporta tamanhos CSS como `px`, `%`, `vh`, `vw`, `rem` e `calc()`, respondendo automaticamente às mudanças do contêiner.
+- **Estados prontos para aplicação**: inclui loading, error, unsupported, download fallback, toolbar, theme e fila de múltiplos arquivos.
+- **Aprimoramento progressivo para formatos complexos**: formatos que o navegador consegue visualizar diretamente são renderizados localmente primeiro; formatos complexos podem integrar gradualmente WASM, parsers dedicados ou conversão no servidor.
 
-## Installation
+## Instalação
 
 ```bash
 pnpm add @open-file-viewer/core
@@ -74,28 +74,28 @@ Svelte:
 pnpm add @open-file-viewer/core @open-file-viewer/svelte
 ```
 
-PDF preview requires `pdfjs-dist` when you use `pdfPlugin()`:
+A visualização de PDF requer `pdfjs-dist` quando você usa `pdfPlugin()`:
 
 ```bash
 pnpm add pdfjs-dist
 ```
 
-You can also use npm or yarn:
+Você também pode usar npm ou yarn:
 
 ```bash
 npm install @open-file-viewer/core
 yarn add @open-file-viewer/core
 ```
 
-Import the shared stylesheet once in your application:
+Importe a folha de estilos compartilhada uma vez na aplicação:
 
 ```ts
 import "@open-file-viewer/core/style.css";
 ```
 
-## Quick Start
+## Início Rápido
 
-### Vanilla JavaScript
+### JavaScript Nativo
 
 ```ts
 import {
@@ -242,53 +242,53 @@ const plugins = [
 />
 ```
 
-## Use Cases
+## Casos de Uso
 
-| Scenario | What Open File Viewer Provides |
+| Cenário | O Que o Open File Viewer Fornece |
 | --- | --- |
-| OA / ERP / CRM attachment centers | A unified container preview for contracts, spreadsheets, images, emails, and archives |
-| Cloud drives / knowledge bases / document systems | Multi-file queues, download, search, fullscreen, and theme adaptation |
-| Low-code / form systems | Vanilla JS integration without forcing React, Vue, or Svelte |
-| Engineering / manufacturing / GIS systems | Recognition and progressive enhancement for CAD, 3D, GIS, and drawing files |
-| Developer platforms / log platforms | Text, config, Markdown, code highlighting, and large-file protection |
+| Centros de anexos OA / ERP / CRM | Visualização unificada em contêiner para contratos, planilhas, imagens, emails e arquivos compactados |
+| Drives em nuvem / bases de conhecimento / sistemas documentais | Fila de múltiplos arquivos, download, busca, tela cheia e adaptação de tema |
+| Sistemas low-code / formulários | Integração com JavaScript nativo sem exigir React, Vue ou Svelte |
+| Engenharia / manufatura / sistemas GIS | Reconhecimento e aprimoramento progressivo para arquivos CAD, 3D, GIS e desenhos |
+| Plataformas de desenvolvimento / logs | Texto, configuração, Markdown, destaque de código e proteção para arquivos grandes |
 
-## Feature Overview
+## Visão Geral de Recursos
 
-| Capability | Status |
+| Recurso | Status |
 | --- | --- |
-| Vanilla JS / React / Vue / Svelte integration | Supported |
-| Custom container, width, height, and responsive sizing | Supported |
-| Multi-file queue, switching, and current index | Supported |
-| Toolbar, download, fullscreen, print, and search | Supported |
-| Light, dark, and `auto` themes | Supported |
-| Local `File` / `Blob` / URL / `ArrayBuffer` sources | Supported |
-| Plugin protocol and custom fallback | Supported |
-| PDF, images, audio/video, text/code | Supported |
-| Office, OFD, EPUB, XPS, email, and archives | Basic to enhanced preview |
-| CAD, 3D, GIS, drawing boards, and design assets | Detection, basic preview, and ongoing enhancements |
+| Integração com JS nativo / React / Vue / Svelte | Suportado |
+| Contêiner, largura, altura e tamanho responsivo personalizados | Suportado |
+| Fila de múltiplos arquivos, troca e índice atual | Suportado |
+| Toolbar, download, tela cheia, impressão e busca | Suportado |
+| Temas light, dark e `auto` | Suportado |
+| Fontes locais `File` / `Blob` / URL / `ArrayBuffer` | Suportado |
+| Protocolo de plugins e fallback personalizado | Suportado |
+| PDF, imagens, áudio/vídeo, texto/código | Suportado |
+| Office, OFD, EPUB, XPS, email e arquivos compactados | Visualização básica a aprimorada |
+| CAD, 3D, GIS, quadros de desenho e ativos de design | Reconhecimento, visualização básica e melhorias contínuas |
 
-## Format Coverage
+## Cobertura de Formatos
 
-| Category | Plugin | Representative Formats |
+| Categoria | Plugin | Formatos Representativos |
 | --- | --- | --- |
-| Images | `imagePlugin()` | `jpg`, `png`, `gif`, `webp`, `avif`, `svg`, `bmp`, `tiff`, `heic`, `heif` |
-| Video | `videoPlugin()` | `mp4`, `webm`, `mov`, `m4v`, `avi`, `mkv`, `flv`, `wmv`, `m3u8`, `m2ts` |
-| Audio | `audioPlugin()` | `mp3`, `wav`, `ogg`, `aac`, `m4a`, `flac`, `opus`, `mid`, `wma` |
-| Text / code | `textPlugin()` | `txt`, `md`, `json`, `yaml`, `xml`, `csv`, `js`, `ts`, `tsx`, `vue`, `html`, `css`, `py`, `go`, `rs`, `sql`, `sh` |
+| Imagens | `imagePlugin()` | `jpg`, `png`, `gif`, `webp`, `avif`, `svg`, `bmp`, `tiff`, `heic`, `heif` |
+| Vídeo | `videoPlugin()` | `mp4`, `webm`, `mov`, `m4v`, `avi`, `mkv`, `flv`, `wmv`, `m3u8`, `m2ts` |
+| Áudio | `audioPlugin()` | `mp3`, `wav`, `ogg`, `aac`, `m4a`, `flac`, `opus`, `mid`, `wma` |
+| Texto / código | `textPlugin()` | `txt`, `md`, `json`, `yaml`, `xml`, `csv`, `js`, `ts`, `tsx`, `vue`, `html`, `css`, `py`, `go`, `rs`, `sql`, `sh` |
 | PDF / ebooks | `pdfPlugin()`, `epubPlugin()`, `xpsPlugin()` | `pdf`, `epub`, `xps`, `oxps` |
 | Office | `officePlugin()` | `docx`, `rtf`, `odt`, `xlsx`, `csv`, `pptx`, `odp`, `wps`, `et`, `dps` |
 | OFD | `ofdPlugin()` | `ofd` |
-| Archives | `archivePlugin()` | `zip`, `rar`, `7z`, `tar`, `gz`, `tgz`, `bz2`, `xz` |
+| Arquivos compactados | `archivePlugin()` | `zip`, `rar`, `7z`, `tar`, `gz`, `tgz`, `bz2`, `xz` |
 | Email | `emailPlugin()` | `eml`, `msg`, `mbox` |
-| Drawing / whiteboard | `drawingPlugin()` | `drawio`, `dio`, `excalidraw`, `tldraw` |
-| CAD / engineering | `cadPlugin()` | `dxf`, `dwg`, `dwf`, `step`, `stp`, `iges`, `igs`, `ifc`, `skp`, `sldprt` |
-| 3D models | `model3dPlugin()` | `gltf`, `glb`, `obj`, `stl`, `fbx`, `dae`, `ply`, `3mf`, `usd`, `usdz` |
+| Desenho / quadro branco | `drawingPlugin()` | `drawio`, `dio`, `excalidraw`, `tldraw` |
+| CAD / engenharia | `cadPlugin()` | `dxf`, `dwg`, `dwf`, `step`, `stp`, `iges`, `igs`, `ifc`, `skp`, `sldprt` |
+| Modelos 3D | `model3dPlugin()` | `gltf`, `glb`, `obj`, `stl`, `fbx`, `dae`, `ply`, `3mf`, `usd`, `usdz` |
 | GIS | `gisPlugin()` | `geojson`, `topojson`, `kml`, `kmz`, `gpx`, `shp` |
-| Asset recognition | `assetPlugin()` | `ttf`, `woff2`, `psd`, `ai`, `eps`, `sqlite`, `wasm`, `parquet`, `avro` |
+| Reconhecimento de ativos | `assetPlugin()` | `ttf`, `woff2`, `psd`, `ai`, `eps`, `sqlite`, `wasm`, `parquet`, `avro` |
 
-Preview quality for complex formats depends on browser capabilities, file structure, and the parser used by each plugin. The current version focuses on making every format enter a controlled preview path inside the container. High-fidelity Office, CAD, design, and proprietary binary formats can continue to integrate dedicated engines or server-side conversion.
+A qualidade da visualização para formatos complexos depende das capacidades do navegador, da estrutura do arquivo e do parser usado por cada plugin. A versão atual prioriza colocar todos os formatos em um caminho de visualização controlado dentro do contêiner. Formatos Office, CAD, de design e binários proprietários de alta fidelidade podem continuar sendo aprimorados com motores dedicados ou conversão no servidor.
 
-Plugin order matters because the first matching plugin renders the file. For example, `csv` and `tsv` can match both `textPlugin()` and `officePlugin()`; place `officePlugin()` earlier if you want spreadsheet-style table preview.
+A ordem dos plugins importa porque o primeiro plugin correspondente renderiza o arquivo. Por exemplo, `csv` e `tsv` podem corresponder tanto a `textPlugin()` quanto a `officePlugin()`; coloque `officePlugin()` antes se quiser visualização em tabela no estilo planilha.
 
 ## Core API
 
@@ -298,32 +298,32 @@ createViewer(options: PreviewOptions): FileViewer;
 
 ### PreviewOptions
 
-| Option | Type | Default | Description |
+| Opção | Tipo | Padrão | Descrição |
 | --- | --- | --- | --- |
-| `container` | `HTMLElement \| string` | Required | Preview container |
-| `file` | `File \| Blob \| string \| ArrayBuffer` | - | Single-file preview source |
-| `files` | `(PreviewSource \| PreviewItem)[]` | - | Multi-file preview queue |
-| `initialIndex` | `number` | `0` | Initial file index |
-| `fileName` | `string` | Auto inferred | File name used for extension detection |
-| `mimeType` | `string` | Auto inferred | MIME type |
-| `width` | `number \| string` | Original container width | Preview container width |
-| `height` | `number \| string` | Original container height | Preview container height |
-| `fit` | `contain \| cover \| width \| height \| actual \| scale-down` | `contain` | Content fitting mode |
-| `plugins` | `PreviewPlugin[]` | `[]` | Plugin list, matched in order |
-| `fallback` | `inline \| download \| custom` | `inline` | Fallback strategy for unsupported formats |
-| `renderFallback` | `(ctx) => PreviewInstance` | - | Custom fallback renderer |
-| `toolbar` | `boolean \| PreviewToolbarOptions` | `false` | Toolbar configuration |
-| `theme` | `light \| dark \| auto` | `light` | Viewer theme |
-| `className` | `string` | - | Extra container class name |
-| `onLoad` | `(file) => void` | - | Callback after loading completes |
-| `onError` | `(error, file) => void` | - | Error callback |
-| `onUnsupported` | `(file) => void` | - | Unsupported-format callback |
+| `container` | `HTMLElement \| string` | Obrigatório | Contêiner de visualização |
+| `file` | `File \| Blob \| string \| ArrayBuffer` | - | Fonte de visualização de arquivo único |
+| `files` | `(PreviewSource \| PreviewItem)[]` | - | Fila de visualização de múltiplos arquivos |
+| `initialIndex` | `number` | `0` | Índice inicial do arquivo |
+| `fileName` | `string` | Inferido automaticamente | Nome usado para detectar extensão |
+| `mimeType` | `string` | Inferido automaticamente | Tipo MIME |
+| `width` | `number \| string` | Largura original do contêiner | Largura do contêiner |
+| `height` | `number \| string` | Altura original do contêiner | Altura do contêiner |
+| `fit` | `contain \| cover \| width \| height \| actual \| scale-down` | `contain` | Modo de ajuste do conteúdo |
+| `plugins` | `PreviewPlugin[]` | `[]` | Lista de plugins, avaliada em ordem |
+| `fallback` | `inline \| download \| custom` | `inline` | Estratégia fallback para formatos não suportados |
+| `renderFallback` | `(ctx) => PreviewInstance` | - | Renderer fallback personalizado |
+| `toolbar` | `boolean \| PreviewToolbarOptions` | `false` | Configuração da toolbar |
+| `theme` | `light \| dark \| auto` | `light` | Tema do viewer |
+| `className` | `string` | - | Classe extra para o contêiner |
+| `onLoad` | `(file) => void` | - | Callback após carregamento |
+| `onError` | `(error, file) => void` | - | Callback de erro |
+| `onUnsupported` | `(file) => void` | - | Callback para formato não suportado |
 
-## Toolbar Customization
+## Personalização da Toolbar
 
-`toolbar: true` enables the default toolbar, including multi-file navigation, zoom, rotate, download, fullscreen, print, and search when supported by the active plugin. You can extend it for business workflows without rewriting the whole viewer.
+`toolbar: true` habilita a toolbar padrão, incluindo navegação de múltiplos arquivos, zoom, rotação, download, tela cheia, impressão e busca quando suportados pelo plugin ativo. Você pode estendê-la para fluxos de negócio sem reescrever todo o viewer.
 
-### Custom Labels, Order, and Icons
+### Labels, Ordem e Ícones Personalizados
 
 ```ts
 createViewer({
@@ -356,7 +356,7 @@ createViewer({
 });
 ```
 
-### Add Business Actions
+### Adicionar Ações de Negócio
 
 ```ts
 createViewer({
@@ -395,7 +395,7 @@ createViewer({
 });
 ```
 
-### Fully Replace the Toolbar
+### Substituir Completamente a Toolbar
 
 ```ts
 createViewer({
@@ -428,9 +428,9 @@ createViewer({
 });
 ```
 
-The `render(ctx)` context includes `file`, `index`, `length`, `previous()`, `next()`, `command()`, `download()`, `fullscreen()`, `print()`, `search()`, and `clearSearch()`. In core, `toolbar.render(ctx)` returns a DOM `HTMLElement | void`; React, Vue, and Svelte expose framework-native toolbar APIs.
+O contexto `render(ctx)` inclui `file`, `index`, `length`, `previous()`, `next()`, `command()`, `download()`, `fullscreen()`, `print()`, `search()` e `clearSearch()`. No core, `toolbar.render(ctx)` retorna um DOM `HTMLElement | void`; React, Vue e Svelte expõem APIs de toolbar próprias de cada framework.
 
-### React Custom Toolbar
+### Toolbar Personalizada no React
 
 ```tsx
 <FileViewer
@@ -448,7 +448,7 @@ The `render(ctx)` context includes `file`, `index`, `length`, `previous()`, `nex
 />
 ```
 
-### Vue Custom Toolbar
+### Toolbar Personalizada no Vue
 
 ```vue
 <OpenFileViewer :files="files" :plugins="plugins">
@@ -462,7 +462,7 @@ The `render(ctx)` context includes `file`, `index`, `length`, `previous()`, `nex
 </OpenFileViewer>
 ```
 
-### Svelte Custom Toolbar
+### Toolbar Personalizada no Svelte
 
 ```svelte
 <OpenFileViewer files={files} plugins={plugins}>
@@ -478,22 +478,22 @@ The `render(ctx)` context includes `file`, `index`, `length`, `previous()`, `nex
 </OpenFileViewer>
 ```
 
-At the style layer, you can still override classes such as `.ofv-toolbar`, `.ofv-toolbar button`, and `.ofv-toolbar-search`. Custom icon buttons also generate `.ofv-toolbar-icon` and `.ofv-toolbar-label`, making alignment, spacing, and truncation easier to control.
+Na camada de estilos, você ainda pode sobrescrever classes como `.ofv-toolbar`, `.ofv-toolbar button` e `.ofv-toolbar-search`. Botões com ícones personalizados também geram `.ofv-toolbar-icon` e `.ofv-toolbar-label`, facilitando controlar alinhamento, espaçamento e truncamento.
 
 ### FileViewer
 
-| Method | Description |
+| Método | Descrição |
 | --- | --- |
-| `reload(file?)` | Reload the current file or a specified file |
-| `next()` / `previous()` | Switch through the multi-file queue |
-| `goTo(index)` | Jump to a specified file |
-| `getCurrentIndex()` | Get the current index |
-| `resize()` | Manually trigger size recalculation |
-| `destroy()` | Destroy the viewer and clean up resources |
+| `reload(file?)` | Recarrega o arquivo atual ou um arquivo especificado |
+| `next()` / `previous()` | Alterna dentro da fila de múltiplos arquivos |
+| `goTo(index)` | Vai para um arquivo específico |
+| `getCurrentIndex()` | Obtém o índice atual |
+| `resize()` | Dispara manualmente o recálculo de tamanho |
+| `destroy()` | Destrói o viewer e limpa recursos |
 
-## Plugin Development
+## Desenvolvimento de Plugins
 
-Each format is integrated through a plugin. A plugin only needs to answer two questions: whether the file matches, and how to render into `ctx.viewport`.
+Cada formato é integrado por meio de um plugin. Um plugin só precisa responder a duas perguntas: se o arquivo corresponde e como renderizar em `ctx.viewport`.
 
 ```ts
 import type { PreviewPlugin } from "@open-file-viewer/core";
@@ -522,37 +522,37 @@ export function customPlugin(): PreviewPlugin {
 }
 ```
 
-Plugin constraints:
+Restrições de plugins:
 
-- Render only into `ctx.viewport`.
-- Do not open a new window by default.
-- Implement `resize(size)` when the plugin needs to react to container size changes.
-- Implement `destroy()` to clean up events, object URLs, timers, Canvas/WebGL resources, and other side effects.
+- Renderizar apenas dentro de `ctx.viewport`.
+- Não abrir uma nova janela por padrão.
+- Implementar `resize(size)` quando o plugin precisar reagir a mudanças de tamanho do contêiner.
+- Implementar `destroy()` para limpar eventos, Object URLs, temporizadores, recursos Canvas/WebGL e outros efeitos colaterais.
 
-## Package Structure
+## Estrutura de Pacotes
 
 ```txt
 packages/
-  core/      # Framework-agnostic preview core and plugins
-  react/     # React adapter
-  vue/       # Vue adapter
-  svelte/    # Svelte adapter
+  core/      # Core de visualização e plugins independentes de framework
+  react/     # Adaptador React
+  vue/       # Adaptador Vue
+  svelte/    # Adaptador Svelte
 examples/
-  vanilla/   # Vanilla JavaScript example
-  react/     # React example
-  vue/       # Vue example
-  svelte/    # Svelte example
-doc/         # Website and online experience
+  vanilla/   # Exemplo com JavaScript nativo
+  react/     # Exemplo React
+  vue/       # Exemplo Vue
+  svelte/    # Exemplo Svelte
+doc/         # Site e experiência online
 ```
 
-## Local Development
+## Desenvolvimento Local
 
 ```bash
 pnpm install
 pnpm check
 ```
 
-Common commands:
+Comandos comuns:
 
 ```bash
 pnpm dev:doc
@@ -568,26 +568,26 @@ pnpm build:doc
 pnpm pack:check
 ```
 
-`pnpm check` runs tests, type checks, package builds, example builds, website build, and package export validation in sequence.
+`pnpm check` executa testes, type checks, builds dos packages, builds dos examples, build do site e validação de package exports em sequência.
 
 ## Roadmap
 
-| Version | Focus |
+| Versão | Foco |
 | --- | --- |
-| `0.1.x` | Core plugin system, in-container preview, React/Vue/Svelte/Vanilla integration, basic multi-format preview |
-| `0.2.x` | Toolbar, themes, image interactions, PDF search, unified states, and fallback |
-| `0.3.x` | Markdown/code reader, enhanced Office spreadsheets and document experience |
-| `0.4.x` | OFD, email, archives, drawing files, and enhancements for high-frequency domestic business formats |
-| `0.5.x` | CAD, 3D, GIS, dedicated parsers, and server-side conversion collaboration |
-| `1.0.0` | Stable API, complete documentation site, visual regression tests, and plugin development guide |
+| `0.1.x` | Sistema de plugins core, visualização dentro do contêiner, integração React/Vue/Svelte/Vanilla, visualização básica de múltiplos formatos |
+| `0.2.x` | Toolbar, temas, interações de imagem, busca em PDF, estados unificados e fallback |
+| `0.3.x` | Leitor Markdown/código, melhorias em planilhas e documentos Office |
+| `0.4.x` | OFD, email, arquivos compactados, desenhos e melhorias para formatos frequentes em negócios domésticos chineses |
+| `0.5.x` | CAD, 3D, GIS, parsers dedicados e colaboração com conversão no servidor |
+| `1.0.0` | API estável, site de documentação completo, testes visuais de regressão e guia de desenvolvimento de plugins |
 
-## Community and Support
+## Comunidade e Suporte
 
-Open File Viewer will continue improving format preview, framework integration, and real business scenarios. Open source is not easy. If it saves you development time, a free GitHub star is a meaningful way to support future iteration.
+Open File Viewer continuará melhorando a visualização de mais formatos, integrações com frameworks e cenários reais de negócio. Manter open source não é fácil. Se ele economizar seu tempo de integração, uma estrela no GitHub ajuda o projeto a continuar evoluindo.
 
-- Feedback: use GitHub Issues, the community group, or the author's WeChat to share file samples, layout problems, container adaptation issues, and new format requests.
-- Learning and discussion: the official account "Frontend Development Enthusiasts" will continue sharing frontend engineering, component development, and open-source practice.
-- Support the author: if you would like to buy the author a coffee, or even a bottle of mineral water, that encouragement is appreciated. Donation users are welcome to add the author's WeChat for future frontend discussions.
+- Feedback: use GitHub Issues, o grupo da comunidade ou o WeChat do autor para compartilhar amostras de arquivos, problemas de layout, adaptação de contêiner e pedidos de novos formatos.
+- Aprendizado e discussão: a conta oficial "Frontend Development Enthusiasts" continuará compartilhando engenharia frontend, desenvolvimento de componentes e prática open source.
+- Apoie o autor: se quiser pagar um café ao autor, ou até uma garrafa de água mineral, esse apoio é muito bem-vindo. Usuários que doarem podem adicionar o WeChat do autor para futuras conversas sobre frontend.
 
 <table>
   <tr>
@@ -631,8 +631,8 @@ Open File Viewer will continue improving format preview, framework integration, 
 
 ## Links
 
-- Website: https://open-file-viewer-workspace.void.app
-- About: https://open-file-viewer-workspace.void.app/about.html
+- Site: https://open-file-viewer-workspace.void.app
+- Sobre: https://open-file-viewer-workspace.void.app/about.html
 - GitHub: https://github.com/xushanpei/open-file-viewer
 - NPM Core: https://www.npmjs.com/package/@open-file-viewer/core
 - NPM React: https://www.npmjs.com/package/@open-file-viewer/react

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -34,7 +34,7 @@
     "access": "public"
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm,cjs --dts --sourcemap --clean && cp src/style.css dist/style.css",
+    "build": "tsup src/index.ts --format esm,cjs --dts --sourcemap --clean && node ../../scripts/copy-file.mjs src/style.css dist/style.css",
     "typecheck": "tsc --noEmit"
   },
   "peerDependenciesMeta": {

--- a/packages/core/src/plugins/office.test.ts
+++ b/packages/core/src/plugins/office.test.ts
@@ -115,6 +115,37 @@ describe("officePlugin", () => {
     expect(container.querySelector(".ofv-formula-list")?.textContent).toContain("B4: =SUM(B2:B3)");
   });
 
+  it("decodes GBK CSV files before rendering sheet cells", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    createViewer({
+      container,
+      file: new Blob(
+        [
+          Uint8Array.from([
+            0xca, 0xd3, 0xc6, 0xb5, 0xc3, 0xfb, 0xb3, 0xc6, 0x2c, 0xbf, 0xaa, 0xca, 0xbc, 0xca, 0xb1, 0xbc,
+            0xe4, 0x28, 0xc3, 0xeb, 0x29, 0x2c, 0xbd, 0xe1, 0xca, 0xf8, 0xca, 0xb1, 0xbc, 0xe4, 0x28, 0xc3,
+            0xeb, 0x29, 0x2c, 0xb6, 0xaf, 0xd7, 0xf7, 0xc3, 0xfb, 0xb3, 0xc6, 0x0a, 0xb0, 0xb2, 0xc8, 0xab,
+            0xb7, 0xc0, 0xbb, 0xa4, 0xd3, 0xeb, 0xca, 0xb5, 0xb2, 0xd9, 0xbc, 0xec, 0xb2, 0xe9, 0x2e, 0x6d,
+            0x70, 0x34, 0x2c, 0x30, 0x2c, 0x31, 0x30, 0x2c, 0xc6, 0xe4, 0xcb, 0xfb, 0x0a
+          ])
+        ],
+        { type: "text/csv" }
+      ),
+      fileName: "action.csv",
+      plugins: [officePlugin()]
+    });
+
+    await waitFor(() => Boolean(container.querySelector(".ofv-sheet-summary")));
+
+    expect(container.querySelector('[data-cell="A1"]')?.textContent).toBe("视频名称");
+    expect(container.querySelector('[data-cell="B1"]')?.textContent).toBe("开始时间(秒)");
+    expect(container.querySelector('[data-cell="A2"]')?.textContent).toBe("安全防护与实操检查.mp4");
+    expect(container.querySelector('[data-cell="D2"]')?.textContent).toBe("其他");
+    expect(container.textContent).not.toContain("��");
+  });
+
   it("renders legacy .xls files when the workbook parser can read them", async () => {
     const xlsx = await import("xlsx");
     const workbook = xlsx.utils.book_new();
@@ -334,6 +365,26 @@ describe("officePlugin", () => {
       renderHeaders: true,
       renderFooters: true
     });
+    expect(container.querySelector(".ofv-docx-document")?.textContent).toContain("DOCX layout page");
+  });
+
+  it("sniffs OOXML Word packages even when they use a legacy .doc extension", async () => {
+    const container = document.createElement("div");
+    const callsBefore = renderDocxAsync.mock.calls.length;
+    document.body.append(container);
+
+    createViewer({
+      container,
+      file: await createMinimalDocx("Mislabeled docx"),
+      fileName: "template.doc",
+      plugins: [officePlugin()]
+    });
+
+    await waitFor(() => Boolean(container.querySelector(".ofv-docx-document")));
+
+    expect(renderDocxAsync).toHaveBeenCalledTimes(callsBefore + 1);
+    expect(container.querySelector(".ofv-office-package-note")?.textContent).toContain("DOCX");
+    expect(container.querySelector(".ofv-office-conversion")).toBeNull();
     expect(container.querySelector(".ofv-docx-document")?.textContent).toContain("DOCX layout page");
   });
 

--- a/packages/core/src/plugins/office.ts
+++ b/packages/core/src/plugins/office.ts
@@ -2,7 +2,7 @@ import JSZip from "jszip";
 import DOMPurify from "dompurify";
 import type { WorkBook } from "xlsx";
 import type { PreviewPlugin } from "../types";
-import { createPanel, createSection, readArrayBuffer, resolveFormat } from "./utils";
+import { createPanel, createSection, decodeTextBuffer, readArrayBuffer, resolveFormat } from "./utils";
 
 const wordExtensions = new Set(["docx", "docm", "doc", "dotx", "dotm", "dot", "rtf", "odt", "fodt", "wps"]);
 const sheetExtensions = new Set(["xlsx", "xls", "xlsm", "xlsb", "xlt", "xltx", "xltm", "csv", "tsv", "ods", "fods", "numbers", "et"]);
@@ -122,9 +122,19 @@ export function officePlugin(): PreviewPlugin {
       ctx.viewport.append(panel);
       const extension = resolveFormat(ctx.file, officeMimeFormatMap);
       const arrayBuffer = await readArrayBuffer(ctx.file);
+      const packageFormat = shouldSniffPackagedOffice(extension) ? await detectPackagedOfficeFormat(arrayBuffer) : undefined;
       let disposeDocxFit: (() => void) | undefined;
 
-      if (fileIsDocx(extension)) {
+      if (packageFormat === "docx" && !fileIsDocx(extension)) {
+        renderOfficePackageNotice(panel, extension, "检测到 OOXML Word 包结构，已按 DOCX 兼容路径预览。");
+        disposeDocxFit = await renderDocx(panel, arrayBuffer);
+      } else if (packageFormat === "xlsx" && !sheetExtensions.has(extension)) {
+        renderOfficePackageNotice(panel, extension, "检测到 OOXML Workbook 包结构，已按 XLSX 兼容路径预览。");
+        await renderSheet(panel, arrayBuffer, "xlsx");
+      } else if (packageFormat === "pptx" && !["pptx", "pptm", "ppsx", "ppsm", "potx", "potm"].includes(extension)) {
+        renderOfficePackageNotice(panel, extension, "检测到 OOXML Presentation 包结构，已按 PPTX 兼容路径预览。");
+        await renderPptx(panel, arrayBuffer);
+      } else if (fileIsDocx(extension)) {
         disposeDocxFit = await renderDocx(panel, arrayBuffer);
       } else if (extension === "rtf") {
         renderPlainDocument(panel, "RTF 文档", rtfToText(await readTextFromBuffer(arrayBuffer)));
@@ -162,6 +172,30 @@ export function officePlugin(): PreviewPlugin {
 
 function fileIsDocx(extension: string): boolean {
   return extension === "docx" || extension === "docm" || extension === "dotx" || extension === "dotm";
+}
+
+function shouldSniffPackagedOffice(extension: string): boolean {
+  return isLegacyOfficeBinary(extension) || packagedOfficeCandidates.has(extension) || extension === "";
+}
+
+async function detectPackagedOfficeFormat(arrayBuffer: ArrayBuffer): Promise<"docx" | "xlsx" | "pptx" | undefined> {
+  try {
+    const zip = await JSZip.loadAsync(arrayBuffer);
+    const entries = Object.values(zip.files).filter((entry) => !entry.dir);
+    const hasEntry = (path: string) => entries.some((entry) => entry.name.toLowerCase() === path.toLowerCase());
+    if (hasEntry("word/document.xml")) {
+      return "docx";
+    }
+    if (hasEntry("xl/workbook.xml")) {
+      return "xlsx";
+    }
+    if (hasEntry("ppt/presentation.xml")) {
+      return "pptx";
+    }
+  } catch {
+    return undefined;
+  }
+  return undefined;
 }
 
 async function renderDocx(panel: HTMLElement, arrayBuffer: ArrayBuffer): Promise<() => void> {
@@ -416,7 +450,10 @@ async function renderSheet(
   const xlsx = await import("xlsx");
   let workbook: WorkBook;
   try {
-    workbook = xlsx.read(arrayBuffer, { type: "array" }) as WorkBook;
+    workbook =
+      extension === "csv" || extension === "tsv"
+        ? (xlsx.read(decodeTextBuffer(arrayBuffer), { type: "string", FS: extension === "tsv" ? "\t" : "," }) as WorkBook)
+        : (xlsx.read(arrayBuffer, { type: "array" }) as WorkBook);
   } catch (error) {
     if (isLegacyOfficeBinary(extension)) {
       renderLegacyOfficeBinary(panel, extension, arrayBuffer, `表格解析失败：${normalizeOfficeError(error)}`);
@@ -2065,7 +2102,7 @@ function rtfToText(rtf: string): string {
 }
 
 async function readTextFromBuffer(arrayBuffer: ArrayBuffer): Promise<string> {
-  return new TextDecoder("utf-8", { fatal: false }).decode(arrayBuffer);
+  return decodeTextBuffer(arrayBuffer);
 }
 
 

--- a/packages/core/src/plugins/text.test.ts
+++ b/packages/core/src/plugins/text.test.ts
@@ -353,6 +353,32 @@ describe("textPlugin", () => {
     ).toBe("true");
   });
 
+  it("decodes GBK text blobs before rendering", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    createViewer({
+      container,
+      file: new Blob(
+        [
+          Uint8Array.from([
+            0xca, 0xd3, 0xc6, 0xb5, 0xc3, 0xfb, 0xb3, 0xc6, 0x2c, 0xbf, 0xaa, 0xca, 0xbc, 0xca, 0xb1, 0xbc,
+            0xe4, 0x28, 0xc3, 0xeb, 0x29
+          ])
+        ],
+        { type: "text/csv" }
+      ),
+      fileName: "action.csv",
+      plugins: [textPlugin()]
+    });
+
+    await waitFor(() => Boolean(container.querySelector(".ofv-code-container code")));
+
+    expect(container.textContent).toContain("视频名称");
+    expect(container.textContent).toContain("开始时间(秒)");
+    expect(container.textContent).not.toContain("��");
+  });
+
   it("copies the full code text from the preview action", async () => {
     const container = document.createElement("div");
     const writeText = vi.fn().mockResolvedValue(undefined);

--- a/packages/core/src/plugins/text.ts
+++ b/packages/core/src/plugins/text.ts
@@ -1,6 +1,7 @@
 /// <reference path="../shims-text.d.ts" />
 import { isTextLike } from "../detect";
 import type { PreviewPlugin } from "../types";
+import { decodeTextBuffer } from "./utils";
 
 const langMap: Record<string, string> = {
   js: "javascript",
@@ -744,13 +745,13 @@ async function readText(source: unknown): Promise<string> {
     if (!response.ok) {
       throw new Error(`Failed to fetch text file: ${response.status}`);
     }
-    return response.text();
+    return decodeTextBuffer(await response.arrayBuffer());
   }
   if (source instanceof Blob) {
-    return source.text();
+    return decodeTextBuffer(await source.arrayBuffer());
   }
   if (source instanceof ArrayBuffer) {
-    return new TextDecoder().decode(source);
+    return decodeTextBuffer(source);
   }
   return String(source);
 }

--- a/packages/core/src/plugins/utils.ts
+++ b/packages/core/src/plugins/utils.ts
@@ -18,18 +18,19 @@ export async function readArrayBuffer(file: PreviewFile): Promise<ArrayBuffer> {
 }
 
 export async function readTextFile(file: PreviewFile): Promise<string> {
+  const decode = (buffer: ArrayBuffer) => decodeTextBuffer(buffer);
   if (typeof file.source === "string") {
     const response = await fetch(file.source);
     if (!response.ok) {
       throw new Error(`Failed to fetch text file: ${response.status}`);
     }
-    return response.text();
+    return decode(await response.arrayBuffer());
   }
   if (file.blob) {
-    return file.blob.text();
+    return decode(await file.blob.arrayBuffer());
   }
   if (file.source instanceof ArrayBuffer) {
-    return new TextDecoder().decode(file.source);
+    return decode(file.source);
   }
   return String(file.source);
 }
@@ -70,7 +71,38 @@ export function escapeHtml(value: string): string {
 }
 
 export function bytesToText(bytes: Uint8Array): string {
-  return new TextDecoder("utf-8", { fatal: false }).decode(bytes);
+  return decodeTextBytes(bytes);
+}
+
+export function decodeTextBuffer(buffer: ArrayBuffer): string {
+  return decodeTextBytes(new Uint8Array(buffer));
+}
+
+export function decodeTextBytes(bytes: Uint8Array): string {
+  if (bytes.length >= 3 && bytes[0] === 0xef && bytes[1] === 0xbb && bytes[2] === 0xbf) {
+    return new TextDecoder("utf-8").decode(bytes.subarray(3));
+  }
+  if (bytes.length >= 2) {
+    if (bytes[0] === 0xff && bytes[1] === 0xfe) {
+      return new TextDecoder("utf-16le").decode(bytes.subarray(2));
+    }
+    if (bytes[0] === 0xfe && bytes[1] === 0xff) {
+      return new TextDecoder("utf-16be").decode(bytes.subarray(2));
+    }
+  }
+  try {
+    return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
+  } catch {
+    return decodeWithFallback(bytes, "gb18030") || decodeWithFallback(bytes, "gbk") || new TextDecoder("utf-8").decode(bytes);
+  }
+}
+
+function decodeWithFallback(bytes: Uint8Array, encoding: string): string | undefined {
+  try {
+    return new TextDecoder(encoding).decode(bytes);
+  } catch {
+    return undefined;
+  }
 }
 
 export function resolveFormat(

--- a/packages/core/src/style.test.ts
+++ b/packages/core/src/style.test.ts
@@ -3,7 +3,7 @@ import { resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 
 const stylePath = resolve(process.cwd(), "packages/core/src/style.css");
-const css = readFileSync(stylePath, "utf8");
+const css = readFileSync(stylePath, "utf8").replace(/\r\n?/g, "\n");
 
 describe("core responsive styles", () => {
   it("keeps the preview shell constrained to its host container", () => {
@@ -151,7 +151,7 @@ describe("core responsive styles", () => {
 });
 
 function rule(selector: string): string {
-  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const escaped = selector.replace(/\r\n?/g, "\n").replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
   const match = css.match(new RegExp(`${escaped}\\s*\\{(?<body>[^}]*)\\}`, "m"));
   if (!match?.groups?.body) {
     throw new Error(`Missing CSS rule for ${selector}.`);

--- a/scripts/copy-file.mjs
+++ b/scripts/copy-file.mjs
@@ -1,0 +1,14 @@
+import { copyFileSync, mkdirSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+
+const [, , source, target] = process.argv;
+
+if (!source || !target) {
+  console.error("Usage: node scripts/copy-file.mjs <source> <target>");
+  process.exit(1);
+}
+
+const resolvedSource = resolve(source);
+const resolvedTarget = resolve(target);
+mkdirSync(dirname(resolvedTarget), { recursive: true });
+copyFileSync(resolvedSource, resolvedTarget);


### PR DESCRIPTION
## Summary
- decode text sources with BOM/UTF-8 detection and GB18030/GBK fallback to fix Chinese CSV/text mojibake
- render CSV/TSV sheets from decoded text and sniff OOXML packages that are mislabeled with legacy extensions like `.doc`
- make Windows verification pass by using a cross-platform CSS copy helper and normalizing CSS test newlines

## Validation
- corepack pnpm exec vitest run packages/core/src/plugins/text.test.ts packages/core/src/plugins/office.test.ts packages/core/src/style.test.ts
- corepack pnpm --filter @open-file-viewer/core typecheck
- corepack pnpm test
- corepack pnpm -r typecheck
- corepack pnpm -r --filter './packages/**' build
- corepack pnpm pack:check

Closes #3