### PR TITLE
Expose GDS/OASIS layout hierarchy and layer controls

### DIFF
--- a/packages/core/src/plugins/cad.test.ts
+++ b/packages/core/src/plugins/cad.test.ts
@@ -403,12 +403,26 @@ describe("cadPlugin", () => {
     expect(container.textContent).toContain("几何1");
     expect(container.querySelector<HTMLElement>(".ofv-layout-summary")?.hidden).toBe(true);
     expect(container.querySelector<HTMLElement>(".ofv-layout-note")?.hidden).toBe(true);
-    expect(container.querySelector<HTMLElement>(".ofv-layout-cells")?.hidden).toBe(true);
-    expect(container.querySelector<HTMLElement>(".ofv-layout-layers")?.hidden).toBe(true);
+    expect(container.querySelector<HTMLElement>(".ofv-layout-cells")?.hidden).toBe(false);
+    expect(container.querySelector<HTMLDetailsElement>(".ofv-layout-cells")?.open).toBe(true);
+    expect(container.querySelector<HTMLElement>(".ofv-layout-layers")?.hidden).toBe(false);
+    expect(container.querySelector(".ofv-layout-grid")?.children).toHaveLength(3);
+    expect(container.querySelector(".ofv-layout-grid")?.children[0].classList.contains("ofv-layout-cells")).toBe(true);
+    expect(container.querySelector(".ofv-layout-grid")?.children[1].classList.contains("ofv-layout-stage")).toBe(true);
+    expect(container.querySelector(".ofv-layout-grid")?.children[2].classList.contains("ofv-layout-layers")).toBe(true);
     expect(visibleText(container)).not.toContain("已从 GDSII Stream");
-    expect(visibleText(container)).not.toContain("Cell 结构");
-    expect(visibleText(container)).not.toContain("图层 1");
+    expect(visibleText(container)).toContain("Cell 结构");
+    expect(visibleText(container)).toContain("图层 1");
     expect(svg?.querySelectorAll("polygon")).toHaveLength(1);
+
+    const layerToggle = container.querySelector<HTMLInputElement>(".ofv-layout-layers input");
+    const polygon = svg?.querySelector<SVGElement>("polygon");
+    expect(layerToggle).not.toBeNull();
+    expect(polygon?.style.display).toBe("");
+    layerToggle?.click();
+    expect(polygon?.style.display).toBe("none");
+    layerToggle?.click();
+    expect(polygon?.style.display).toBe("");
 
     container.querySelector<HTMLButtonElement>('button[aria-label="Zoom in"]')?.click();
     expect(svg?.getAttribute("viewBox")).not.toBe(initialViewBox);
@@ -434,8 +448,8 @@ describe("cadPlugin", () => {
     expect(container.textContent).toContain("引用2");
     expect(container.textContent).toContain("展开几何2");
     expect(container.textContent).toContain("1 (3)");
-    expect(container.querySelector<HTMLElement>(".ofv-layout-cells")?.hidden).toBe(true);
-    expect(visibleText(container)).not.toContain("Cell 结构");
+    expect(container.querySelector<HTMLElement>(".ofv-layout-cells")?.hidden).toBe(false);
+    expect(visibleText(container)).toContain("Cell 结构");
     expect(container.querySelectorAll(".ofv-layout-stage polygon")).toHaveLength(3);
   });
 
@@ -478,10 +492,10 @@ describe("cadPlugin", () => {
     expect(container.textContent).toContain("CBLOCK");
     expect(container.querySelector<HTMLElement>(".ofv-layout-summary")?.hidden).toBe(true);
     expect(container.querySelector<HTMLElement>(".ofv-layout-note")?.hidden).toBe(true);
-    expect(container.querySelector<HTMLElement>(".ofv-layout-cells")?.hidden).toBe(true);
-    expect(container.querySelector<HTMLElement>(".ofv-layout-layers")?.hidden).toBe(true);
+    expect(container.querySelector<HTMLElement>(".ofv-layout-cells")?.hidden).toBe(false);
+    expect(container.querySelector<HTMLElement>(".ofv-layout-layers")?.hidden).toBe(false);
     expect(visibleText(container)).not.toContain("OASIS 是高压缩芯片版图格式");
-    expect(visibleText(container)).not.toContain("Cell 结构");
+    expect(visibleText(container)).toContain("Cell 结构");
     expect(container.querySelector(".ofv-layout-stage polygon")).not.toBeNull();
   });
 

--- a/packages/core/src/plugins/cad.ts
+++ b/packages/core/src/plugins/cad.ts
@@ -769,18 +769,22 @@ function renderLayoutPreview(
     svg.append(text);
   }
 
+  const layoutGrid = document.createElement("div");
+  layoutGrid.className = "ofv-layout-grid";
+
   const layers = [...data.layers.keys()].sort((a, b) => a.localeCompare(b));
+  const cellList = data.cells.length > 0 ? createLayoutCellList(data.cells, data.references) : undefined;
+  if (cellList) {
+    layoutGrid.append(cellList);
+  }
+
+  layoutGrid.append(svg);
+
   if (layers.length > 0) {
     const layerControls = createLayoutLayerControls(svg, layers, data.layers);
-    if (hasDrawableLayout(data)) {
-      hideSupplementalInfo(layerControls);
-    }
-    section.append(layerControls);
+    layoutGrid.append(layerControls);
   }
-  section.append(svg);
-  if (data.cells.length > 0) {
-    section.append(createLayoutCellList(data.cells, data.references, hasDrawableLayout(data)));
-  }
+  section.append(layoutGrid);
   panel.append(section);
 
   const updateToolbarZoom = () => ctx.toolbar?.setZoom(initialViewBox.width / currentViewBox.width);

--- a/packages/core/src/plugins/render-smoke.test.ts
+++ b/packages/core/src/plugins/render-smoke.test.ts
@@ -3963,8 +3963,8 @@ function cleanPreviewCases(): CleanPreviewCase[] {
       plugins: [cadPlugin()],
       selector: ".ofv-layout-stage",
       text: "GDSII",
-      hiddenText: ["Cell", "几何", "引用", "文字"],
-      hiddenSelectors: [".ofv-layout-summary", ".ofv-layout-note", ".ofv-layout-cells", ".ofv-layout-layers"]
+      hiddenText: ["几何", "引用", "文字"],
+      hiddenSelectors: [".ofv-layout-summary", ".ofv-layout-note"]
     },
     {
       name: "OASIS layout",
@@ -3973,8 +3973,8 @@ function cleanPreviewCases(): CleanPreviewCase[] {
       plugins: [cadPlugin()],
       selector: ".ofv-layout-stage",
       text: "OASIS",
-      hiddenText: ["Cell", "几何", "引用", "文字"],
-      hiddenSelectors: [".ofv-layout-summary", ".ofv-layout-note", ".ofv-layout-cells", ".ofv-layout-layers"]
+      hiddenText: ["几何", "引用", "文字"],
+      hiddenSelectors: [".ofv-layout-summary", ".ofv-layout-note"]
     },
     {
       name: "3D model",

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -2010,6 +2010,27 @@
   color: var(--ofv-text);
 }
 
+.ofv-layout-grid {
+  display: grid;
+  grid-template-columns: minmax(180px, 260px) minmax(0, 1fr) minmax(180px, 260px);
+  gap: 12px;
+  align-items: start;
+  min-width: 0;
+  max-width: 100%;
+}
+
+.ofv-layout-grid .ofv-layout-stage {
+  min-height: 420px;
+  height: min(620px, 68vh);
+}
+
+.ofv-layout-grid .ofv-layout-cells,
+.ofv-layout-grid .ofv-layout-layers {
+  max-height: min(620px, 68vh);
+  overflow: auto;
+  overscroll-behavior: contain;
+}
+
 .ofv-drawing-summary {
   display: flex;
   flex-wrap: wrap;
@@ -2070,6 +2091,16 @@
 
 .ofv-cad-layers input {
   margin: 0;
+}
+
+.ofv-layout-grid .ofv-layout-layers {
+  display: grid;
+  align-content: start;
+  align-items: stretch;
+}
+
+.ofv-layout-grid .ofv-layout-layers label {
+  border-radius: 6px;
 }
 
 .ofv-cad-summary {
@@ -3101,6 +3132,17 @@
   color: var(--ofv-text);
   min-width: 0;
   max-width: 280px;
+}
+
+@container (max-width: 760px) {
+  .ofv-layout-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .ofv-layout-grid .ofv-layout-stage {
+    min-height: 320px;
+    height: min(520px, 62vh);
+  }
 }
 
 .ofv-map-popup h4 {

--- a/packages/core/src/style.test.ts
+++ b/packages/core/src/style.test.ts
@@ -194,6 +194,10 @@ describe("core responsive styles", () => {
     expect(rule(".ofv-email-attachments")).toContain("min-width: 0");
     expect(rule(".ofv-email-attachment-item")).toContain("max-width: 100%");
     expect(rule(".ofv-email-body-iframe")).toContain("max-width: 100%");
+    expect(rule(".ofv-layout-grid")).toContain("grid-template-columns");
+    expect(rule(".ofv-layout-grid")).toContain("minmax(180px, 260px)");
+    expect(rule(".ofv-layout-grid .ofv-layout-cells,\n.ofv-layout-grid .ofv-layout-layers")).toContain("overflow: auto");
+    expect(css).toContain(".ofv-layout-grid .ofv-layout-layers {\n  display: grid");
     expect(rule(".ofv-cad-layers")).toContain("flex-wrap: wrap");
     expect(rule(".ofv-cad-layers")).toContain("min-width: 0");
     expect(rule(".ofv-gis-viewer")).toContain("min-height: 320px");


### PR DESCRIPTION
## Summary
- show the GDS/OASIS cell hierarchy next to the layout preview instead of hiding it for clean previews
- show layer controls on the right side and keep their checkbox visibility toggles functional
- add a responsive layout grid so hierarchy, canvas, and layers remain usable on narrow containers

## Notes
This focuses on the hierarchy/layer usability requested in #1. It does not attempt to replace the existing parser with a full high-fidelity OASIS geometry implementation.

Refs #1

## Verification
- `corepack pnpm vitest run packages/core/src/plugins/cad.test.ts packages/core/src/style.test.ts`
- `corepack pnpm vitest run packages/core/src/plugins/render-smoke.test.ts -t "GDS layout|OASIS layout|supplemental metadata"`
- `corepack pnpm -r typecheck`
- `git diff --check`
- `corepack pnpm test`
- `corepack pnpm -r --filter './packages/**' build`
- `corepack pnpm -r --filter './examples/**' build`
- `corepack pnpm --filter @open-file-viewer/doc build`
- `corepack pnpm pack:check`