### PR TITLE
Keep code preview text readable in hosted pages

### DIFF
--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -3729,6 +3729,7 @@
   max-width: 100%;
   min-width: max-content;
   background: transparent !important;
+  color: var(--ofv-text);
   font-family: var(--ofv-font-mono, ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace);
   font-size: calc(13px * var(--ofv-text-zoom, 1));
   line-height: 1.6;

--- a/packages/core/src/style.test.ts
+++ b/packages/core/src/style.test.ts
@@ -92,6 +92,7 @@ describe("core responsive styles", () => {
     expect(rule(".ofv-code-gutter")).toContain("z-index: 3");
     expect(rule(".ofv-code-gutter")).toContain("background: var(--ofv-surface)");
     expect(rule(".ofv-code-container pre")).toContain("z-index: 0");
+    expect(rule(".ofv-code-container pre")).toContain("color: var(--ofv-text)");
     expect(rule(".ofv-code-actions")).toContain("flex-wrap: nowrap");
     expect(rule(".ofv-code-action")).toContain("white-space: nowrap");
     expect(rule(".ofv-code-status")).toContain("text-overflow: ellipsis");


### PR DESCRIPTION
## Summary
- ensure the core code preview `<pre>` uses the viewer text color instead of inheriting host page `pre` colors
- add a style regression assertion for the code preview text color

## Notes
This addresses the text/CSS preview contrast issue reported in #35. The fix is intentionally scoped to the code preview surface and does not change Office/PDF/chart rendering behavior.

Fixes #35

## Verification
- `corepack pnpm vitest run packages/core/src/style.test.ts packages/core/src/plugins/text.test.ts`
- `corepack pnpm test`
- `corepack pnpm@9.15.0 -r typecheck`
- `corepack pnpm@9.15.0 --filter @open-file-viewer/core build`
- `corepack pnpm@9.15.0 --filter @open-file-viewer/doc build`
- `corepack pnpm@9.15.0 --filter @open-file-viewer/react build`
- `corepack pnpm@9.15.0 --filter @open-file-viewer/vue build`
- `corepack pnpm@9.15.0 --filter @open-file-viewer/svelte build`
- `corepack pnpm@9.15.0 --filter @open-file-viewer/example-vanilla build`
- `corepack pnpm@9.15.0 --filter @open-file-viewer/example-react build`
- `corepack pnpm@9.15.0 --filter @open-file-viewer/example-vue build`
- `corepack pnpm@9.15.0 --filter @open-file-viewer/example-svelte build`
- `corepack pnpm@9.15.0 pack:check`
- `git diff --check`
- JSDOM cascade check: with core CSS followed by doc CSS, `.ofv-code-container pre/code` compute to `var(--ofv-text)`; without the new rule they compute to doc `var(--code-text)`