### PR TITLE
Improve legacy .doc form table rendering

### DIFF
--- a/packages/core/src/plugins/msdoc.ts
+++ b/packages/core/src/plugins/msdoc.ts
@@ -61,8 +61,17 @@ export type LegacyWordBlock =
   | { type: "listItem"; text: string; level: 1 | 2 }
   | { type: "heading"; text: string; level: 1 | 2 | 3; indent?: boolean }
   | { type: "toc"; title: string; page?: string; level: number }
-  | { type: "table"; rows: string[][] }
+  | { type: "table"; rows: LegacyWordTableRow[] }
   | { type: "pageBreak" };
+
+export type LegacyWordTableCell =
+  | string
+  | { text: string; colSpan?: number; variant?: "label" | "section" | "caption" | "body" | "empty" };
+
+export type LegacyWordTableRow = LegacyWordTableCell[];
+
+type LegacyWordTableCellData = Extract<LegacyWordTableCell, { text: string }>;
+type LegacyWordTableCellVariant = NonNullable<LegacyWordTableCellData["variant"]>;
 
 type CompoundDirectoryEntry = {
   name: string;
@@ -307,6 +316,8 @@ function renderWordBlock(block: LegacyWordBlock): HTMLElement {
     const table = window.document.createElement("table");
     table.className = "ofv-msdoc-table";
     const revisionColumnWidths = getRevisionTableColumnWidths(block.rows);
+    const renderRows = revisionColumnWidths ? block.rows : normalizeLegacyFormTableRows(block.rows);
+    const isFormTable = renderRows.some((row) => row.some((cell) => getTableCellVariant(cell) !== undefined));
     if (revisionColumnWidths) {
       table.classList.add("ofv-msdoc-revision-table");
       const colgroup = window.document.createElement("colgroup");
@@ -317,13 +328,23 @@ function renderWordBlock(block: LegacyWordBlock): HTMLElement {
       }
       table.append(colgroup);
     }
+    if (isFormTable) {
+      table.classList.add("ofv-msdoc-form-table");
+    }
     const tbody = window.document.createElement("tbody");
-    for (const row of block.rows) {
+    for (const row of renderRows) {
       const tr = window.document.createElement("tr");
-      const cellTag = row === block.rows[0] && block.rows.length > 1 ? "th" : "td";
-      for (const cellText of row) {
+      const cellTag = !isFormTable && row === renderRows[0] && renderRows.length > 1 ? "th" : "td";
+      for (const cellData of row) {
+        const cellInfo = normalizeTableCell(cellData);
         const cell = window.document.createElement(cellTag);
-        cell.textContent = cellText;
+        cell.textContent = cellInfo.text;
+        if (cellInfo.colSpan && cellInfo.colSpan > 1) {
+          cell.colSpan = cellInfo.colSpan;
+        }
+        if (cellInfo.variant) {
+          cell.classList.add(`ofv-msdoc-form-${cellInfo.variant}`);
+        }
         tr.append(cell);
       }
       tbody.append(tr);
@@ -414,8 +435,8 @@ function appendBracketRun(element: HTMLElement, value: string): void {
   element.append(run);
 }
 
-function getRevisionTableColumnWidths(rows: string[][]): number[] | undefined {
-  const header = rows[0]?.map((cell) => cell.toLowerCase());
+function getRevisionTableColumnWidths(rows: LegacyWordTableRow[]): number[] | undefined {
+  const header = rows[0]?.map((cell) => getTableCellText(cell).toLowerCase());
   if (!header || header.length !== 4) {
     return undefined;
   }
@@ -423,6 +444,116 @@ function getRevisionTableColumnWidths(rows: string[][]): number[] | undefined {
     return [59, 81, 106, 191];
   }
   return undefined;
+}
+
+function normalizeLegacyFormTableRows(rows: LegacyWordTableRow[]): LegacyWordTableRow[] {
+  if (rows.length === 0) {
+    return rows;
+  }
+  const normalized: LegacyWordTableRow[] = [];
+  let index = 0;
+  const leadingLabels = getLeadingFormLabels(rows);
+  if (leadingLabels) {
+    for (let offset = 0; offset < leadingLabels.length; offset += 2) {
+      normalized.push([
+        createFormCell(leadingLabels[offset] || "", "label"),
+        createFormCell("", "empty"),
+        createFormCell(leadingLabels[offset + 1] || "", "label"),
+        createFormCell("", "empty")
+      ]);
+    }
+    index = 2;
+  }
+
+  for (; index < rows.length; index += 1) {
+    const sectionRows = splitFormSectionRow(rows[index]);
+    if (sectionRows) {
+      normalized.push(...sectionRows);
+      continue;
+    }
+    normalized.push(rows[index].map((cell) => normalizeTableCell(cell)));
+  }
+
+  return normalized;
+}
+
+function getLeadingFormLabels(rows: LegacyWordTableRow[]): string[] | undefined {
+  if (rows.length < 3 || rows[0].length !== 3 || rows[1].length !== 3 || !isFormSectionRow(rows[2])) {
+    return undefined;
+  }
+  const labels = [...rows[0], ...rows[1]].map(getTableCellText);
+  if (labels.length !== 6 || !labels.every(isShortChineseFormLabel)) {
+    return undefined;
+  }
+  return labels;
+}
+
+function splitFormSectionRow(row: LegacyWordTableRow): LegacyWordTableRow[] | undefined {
+  const cells = row.map((cell) => normalizeTableCell(cell)).filter((cell) => cell.text.length > 0);
+  const sectionIndex = cells.findIndex((cell) => isChineseSectionTitle(cell.text));
+  if (sectionIndex < 0) {
+    return undefined;
+  }
+  const gradeIndex = cells.findIndex((cell, index) => index > sectionIndex && isGradeCell(cell.text));
+  if (gradeIndex < 0) {
+    return undefined;
+  }
+
+  const output: LegacyWordTableRow[] = [];
+  const leadingText = cells
+    .slice(0, sectionIndex)
+    .map((cell) => cell.text)
+    .join(" ")
+    .trim();
+  if (leadingText) {
+    output.push([createFormCell(leadingText, "body", 4)]);
+  }
+
+  output.push([createFormCell(cells[sectionIndex].text, "section", 2), createFormCell(cells[gradeIndex].text, "section", 2)]);
+
+  const trailingText = cells
+    .slice(gradeIndex + 1)
+    .map((cell) => cell.text)
+    .join(" ")
+    .trim();
+  if (trailingText) {
+    output.push([createFormCell(trailingText, "caption", 4)]);
+  }
+
+  return output;
+}
+
+function isFormSectionRow(row: LegacyWordTableRow): boolean {
+  return splitFormSectionRow(row) !== undefined;
+}
+
+function createFormCell(text: string, variant: LegacyWordTableCellVariant, colSpan?: number): LegacyWordTableCell {
+  return { text, variant, colSpan };
+}
+
+function normalizeTableCell(cell: LegacyWordTableCell): LegacyWordTableCellData {
+  return typeof cell === "string" ? { text: cell } : cell;
+}
+
+function getTableCellText(cell: LegacyWordTableCell): string {
+  return normalizeTableCell(cell).text.trim();
+}
+
+function getTableCellVariant(cell: LegacyWordTableCell): LegacyWordTableCellVariant | undefined {
+  return normalizeTableCell(cell).variant;
+}
+
+function isShortChineseFormLabel(text: string): boolean {
+  const value = text.trim();
+  return value.length > 0 && value.length <= 8 && /\p{Script=Han}/u.test(value) && !/[。；，、：:]/.test(value);
+}
+
+function isChineseSectionTitle(text: string): boolean {
+  return /^[一二三四五六七八九十]+、\S+/.test(text.trim());
+}
+
+function isGradeCell(text: string): boolean {
+  return /^成绩[:：]?$/.test(text.trim());
 }
 
 function appendInlineText(element: HTMLElement, text: string, preserveTabs: boolean): void {

--- a/packages/core/src/plugins/office.test.ts
+++ b/packages/core/src/plugins/office.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from "vitest";
 import { existsSync, readFileSync } from "node:fs";
 import JSZip from "jszip";
 import { createViewer } from "../viewer";
+import { renderLegacyWordDocument, type LegacyWordDocument } from "./msdoc";
 import { officePlugin } from "./office";
 
 const shouldFailDocxPreview = vi.hoisted(() => ({ value: false }));
@@ -1364,6 +1365,69 @@ describe("officePlugin", () => {
     expect(container.querySelector(".ofv-msdoc-document")?.textContent).not.toContain("HYPERLINK");
     expect(container.querySelector(".ofv-msdoc-document")?.textContent).not.toContain("PAGEREF");
     expect(container.querySelector(".ofv-msdoc-document")?.textContent).not.toContain("REF rfc2119");
+  });
+
+  it("expands recovered legacy Word form tables into styled section rows", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const documentModel: LegacyWordDocument = {
+      title: "实训一 纯电动汽车高压断电流程实训",
+      paragraphs: [],
+      blocks: [
+        { type: "title", text: "实训一 纯电动汽车高压断电流程实训" },
+        {
+          type: "table",
+          rows: [
+            ["学院", "专业", "姓名"],
+            ["学号", "小组成员", "组长姓名"],
+            ["一、接受工作任务", "成绩：", "企业工作任务"],
+            [
+              "新能源汽车服务有限公司昨日接收一辆北汽新能源EV系列纯电动汽车，需完成作业前准备及高压断电流程。",
+              "二、信息收集",
+              "成绩：",
+              "请查阅相关资料，完成以下信息的填写。"
+            ]
+          ]
+        }
+      ],
+      layout: { lineNumbers: false },
+      assets: [],
+      styles: [],
+      stats: {
+        streamCount: 7,
+        pieceCount: 4,
+        characterCount: 120,
+        styleCount: 0,
+        tableStream: "1Table"
+      },
+      warnings: []
+    };
+
+    renderLegacyWordDocument(container, documentModel);
+
+    const table = container.querySelector<HTMLTableElement>(".ofv-msdoc-form-table");
+    expect(table).not.toBeNull();
+    const rows = Array.from(table?.rows || []);
+    expect(rows).toHaveLength(8);
+    expect(Array.from(rows[0].cells).map((cell) => cell.textContent)).toEqual(["学院", "", "专业", ""]);
+    expect(rows[0].cells[0].classList.contains("ofv-msdoc-form-label")).toBe(true);
+    expect(rows[0].cells[1].classList.contains("ofv-msdoc-form-empty")).toBe(true);
+    expect(Array.from(rows[2].cells).map((cell) => cell.textContent)).toEqual(["小组成员", "", "组长姓名", ""]);
+    expect(rows[3].cells[0].textContent).toBe("一、接受工作任务");
+    expect(rows[3].cells[0].colSpan).toBe(2);
+    expect(rows[3].cells[1].textContent).toBe("成绩：");
+    expect(rows[3].cells[1].colSpan).toBe(2);
+    expect(rows[3].cells[0].classList.contains("ofv-msdoc-form-section")).toBe(true);
+    expect(rows[4].cells[0].textContent).toBe("企业工作任务");
+    expect(rows[4].cells[0].colSpan).toBe(4);
+    expect(rows[4].cells[0].classList.contains("ofv-msdoc-form-caption")).toBe(true);
+    expect(rows[5].cells[0].textContent).toContain("新能源汽车服务有限公司");
+    expect(rows[5].cells[0].colSpan).toBe(4);
+    expect(rows[5].cells[0].classList.contains("ofv-msdoc-form-body")).toBe(true);
+    expect(rows[6].cells[0].textContent).toBe("二、信息收集");
+    expect(rows[6].cells[0].colSpan).toBe(2);
+    expect(rows[7].cells[0].textContent).toContain("请查阅相关资料");
+    expect(rows[7].cells[0].colSpan).toBe(4);
   });
 
   it("keeps literal ASCII text from legacy Word binaries even when it looks random", async () => {

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -1025,6 +1025,14 @@
   table-layout: fixed;
 }
 
+.ofv-msdoc-form-table {
+  width: 100%;
+  table-layout: fixed;
+  border: 2px solid #111827;
+  color: #111827;
+  font-family: "Microsoft YaHei", "PingFang SC", Arial, Helvetica, sans-serif;
+}
+
 .ofv-msdoc-table th,
 .ofv-msdoc-table td {
   padding: 0 calc(5px * var(--ofv-office-zoom, 1));
@@ -1037,6 +1045,37 @@
 .ofv-msdoc-table th {
   background: #f8fafc;
   font-weight: 700;
+}
+
+.ofv-msdoc-form-table th,
+.ofv-msdoc-form-table td {
+  min-height: calc(34px * var(--ofv-office-zoom, 1));
+  padding: calc(6px * var(--ofv-office-zoom, 1)) calc(8px * var(--ofv-office-zoom, 1));
+  border-color: #111827;
+  font-size: calc(11pt * var(--ofv-office-zoom, 1));
+  line-height: 1.45;
+}
+
+.ofv-msdoc-form-label,
+.ofv-msdoc-form-section {
+  background: #b7e63a;
+  font-weight: 700;
+}
+
+.ofv-msdoc-form-label {
+  text-align: center;
+}
+
+.ofv-msdoc-form-section {
+  font-size: calc(12pt * var(--ofv-office-zoom, 1));
+}
+
+.ofv-msdoc-form-caption {
+  font-weight: 700;
+}
+
+.ofv-msdoc-form-empty {
+  background: #fff;
 }
 
 .ofv-msdoc-meta,


### PR DESCRIPTION
## Summary
- detect recovered legacy `.doc` form tables that contain short Chinese label rows plus chapter/score rows
- expand those rows into a stable 4-column form layout with `colSpan` support
- add form-table styling and a regression test for the issue #39 table shape

## Validation
- `corepack pnpm@9.15.0 --filter @open-file-viewer/core typecheck`
- `corepack pnpm@9.15.0 exec vitest run packages/core/src/plugins/office.test.ts --reporter=verbose`
- `corepack pnpm@9.15.0 --filter @open-file-viewer/core build`
- `corepack pnpm@9.15.0 pack:check`
- `corepack pnpm@9.15.0 test` (26 files / 1726 tests)
- `corepack pnpm@9.15.0 typecheck`
- `corepack pnpm@9.15.0 build:doc`
- `corepack pnpm@9.15.0 build:examples` (script completed with no matched example projects)
- `git diff --check` (only existing CRLF conversion warnings on Windows)
- manually loaded the issue #39 `.doc` sample and verified the first recovered table renders as `.ofv-msdoc-form-table` with label rows, section rows, and expected `colSpan`s

Refs #39