### PR TITLE
Fix workspace build scripts on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "url": "https://github.com/xushanpei/open-file-viewer/issues"
   },
   "scripts": {
-    "build": "pnpm -r --filter './packages/**' build",
+    "build": "pnpm -r --filter ./packages/** build",
     "build:doc": "pnpm --filter @open-file-viewer/doc build",
-    "build:examples": "pnpm -r --filter './examples/**' build",
+    "build:examples": "pnpm -r --filter ./examples/** build",
     "pack:check": "node scripts/check-package-exports.mjs",
     "typecheck": "pnpm -r typecheck",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- remove single quotes from root pnpm workspace filter scripts
- make pnpm build and pnpm build:examples actually match workspace packages when run through npm/pnpm scripts on Windows

## Why
On Windows, the quoted filter values are passed through as literal quote characters when invoked from package scripts, so pnpm reports no matching projects while still exiting successfully. Removing the quotes keeps the filters cross-platform and avoids false-positive build checks.

## Verification
- pnpm build
- pnpm build:examples
- pnpm check (test, typecheck, packages build, examples build, doc build, package export check)