### PR TITLE
fix(office): preserve PPTX slide backgrounds

### DIFF
--- a/packages/core/src/plugins/office.test.ts
+++ b/packages/core/src/plugins/office.test.ts
@@ -58,7 +58,7 @@ const openPptx = vi.hoisted(() =>
     page.style.height = "720px";
     page.style.transform = "scale(0.75)";
     page.textContent = "PPTX rendered";
-    page.style.backgroundColor = "transparent";
+    page.style.backgroundColor = "rgb(32, 33, 36)";
     const mirroredTextGroup = document.createElement("div");
     mirroredTextGroup.className = "pptx-mirrored-text-group";
     mirroredTextGroup.style.position = "absolute";
@@ -1182,7 +1182,7 @@ describe("officePlugin", () => {
     expect(container.querySelector(".ofv-presentation-slides")).toBeNull();
     expect(container.querySelector(".ofv-pptx-viewer")?.textContent).toContain("PPTX rendered");
     expect(visibleText(container)).not.toContain("PPTX 演示文稿结构");
-    expect(container.querySelector<HTMLElement>(".pptx-rendered")?.style.backgroundColor).toBe("rgb(255, 255, 255)");
+    expect(container.querySelector<HTMLElement>(".pptx-rendered")?.style.backgroundColor).toBe("rgb(32, 33, 36)");
     expect(container.querySelector<HTMLElement>(".pptx-mirrored-text-group > div")?.style.transform).toBe("scaleX(-1)");
     expect(container.querySelector<HTMLElement>(".pptx-mirrored-text-group > div")?.dataset.ofvPptxCounterMirror).toBe("x");
   });

--- a/packages/core/src/plugins/office.ts
+++ b/packages/core/src/plugins/office.ts
@@ -3377,9 +3377,15 @@ function pptxRenderTimeoutMs(): number {
 function normalizePptxLayout(container: HTMLElement): void {
   const slideCanvases = findPptxSlideCanvases(container);
   for (const slide of slideCanvases) {
-    slide.style.backgroundColor = "#FFFFFF";
+    if (!hasInlineBackground(slide)) {
+      slide.style.backgroundColor = "#FFFFFF";
+    }
   }
   normalizePptxMirroredText(container);
+}
+
+function hasInlineBackground(element: HTMLElement): boolean {
+  return Boolean(element.style.background || element.style.backgroundColor || element.style.backgroundImage);
 }
 
 function normalizePptxMirroredText(container: HTMLElement): void {


### PR DESCRIPTION
## Summary
- preserve inline PPTX slide backgrounds emitted by the PPTX renderer
- keep the existing white fallback only for slide canvas elements without any inline background
- add a regression assertion for a dark PPTX slide background

## Why
Fixes #47. normalizePptxLayout was unconditionally setting detected slide canvas backgrounds to white, which can override dark / gray PPTX designs such as LINEAR-style decks.

## Verification
- pnpm vitest run packages/core/src/plugins/office.test.ts
- pnpm test
- pnpm typecheck
- pnpm -r --filter ./packages/** build
- pnpm pack:check