### PR TITLE
fix(core): detect CDN-styled URL extensions

### DIFF
--- a/packages/core/src/detect.test.ts
+++ b/packages/core/src/detect.test.ts
@@ -5,6 +5,7 @@ describe("detect", () => {
   it("extracts extensions from names and urls", () => {
     expect(getExtension("report.final.DOCX")).toBe("docx");
     expect(getExtension("https://example.com/files/demo.pdf?download=1#page=2")).toBe("pdf");
+    expect(getExtension("https://example.com/files/photo.jpg!wx750")).toBe("jpg");
     expect(getExtension("README")).toBe("");
   });
 
@@ -20,10 +21,13 @@ describe("detect", () => {
   it("decodes file names from remote URL sources", async () => {
     const file = await normalizeFile("https://example.com/files/%E5%88%AB%E5%A2%85%E5%9B%BE%E7%BA%B8.dwg?download=1");
     const malformed = await normalizeFile("https://example.com/files/bad%name.dwg");
+    const styledImage = await normalizeFile("https://files.sciconf.cn/public/2024/0/202509/2025091418475086759124310.jpg!wx750");
 
     expect(file.name).toBe("别墅图纸.dwg");
     expect(file.extension).toBe("dwg");
     expect(malformed.name).toBe("bad%name.dwg");
+    expect(styledImage.extension).toBe("jpg");
+    expect(styledImage.mimeType).toBe("image/jpeg");
   });
 
   it("infers MIME types for common complex preview formats", async () => {

--- a/packages/core/src/detect.ts
+++ b/packages/core/src/detect.ts
@@ -343,7 +343,7 @@ function getFileNameFromUrl(source: string): string {
 export function getExtension(name: string): string {
   const clean = name.split("?")[0]?.split("#")[0] || "";
   const index = clean.lastIndexOf(".");
-  return index >= 0 ? clean.slice(index + 1).toLowerCase() : "";
+  return index >= 0 ? clean.slice(index + 1).split("!", 1)[0].toLowerCase() : "";
 }
 
 export function isTextLike(file: PreviewFile): boolean {


### PR DESCRIPTION
## Summary
- detect CDN-styled URL suffixes such as `.jpg!wx750` as their real file extension
- keep existing signed URL query handling unchanged
- add regression coverage for the issue URL shape

## Why
Fixes #49. URLs using image style suffixes can currently produce extensions like `jpg!wx750`, leaving the MIME type empty and preventing image previews from matching the image plugin.

## Verification
- `corepack pnpm vitest run packages/core/src/detect.test.ts --reporter verbose`
- `node -e "import('./packages/core/src/detect.ts').then(async m=>{...})"` for the issue URL examples
- `corepack pnpm test`
- `corepack pnpm -r typecheck`
- `corepack pnpm -r --filter ./packages/** build`
- `corepack pnpm pack:check`