### PR TITLE
fix(core): localize preview guidance messages

### DIFF
--- a/packages/core/src/messages.ts
+++ b/packages/core/src/messages.ts
@@ -15,7 +15,43 @@ export const defaultMessages: Record<PreviewLocale, PreviewMessages> = {
     size: "大小",
     source: "来源",
     remoteUrl: "远程 URL",
-    localFile: "本地/内存文件"
+    localFile: "本地/内存文件",
+    textPlainLanguage: "纯文本",
+    textLineCount: "{count} 行",
+    textWrap: "换行",
+    textCopy: "复制",
+    textCopied: "已复制",
+    textCopyFailed: "复制失败",
+    textDownload: "下载",
+    textDownloadReady: "下载已准备",
+    textLargeFileNotice: "文件较大，当前展示前 {size}，复制和下载仍会使用完整内容。",
+    textHighlightSkipped: "内容较大，已跳过语法高亮以保持滚动流畅。",
+    textPreviewFailedTitle: "文本预览失败",
+    textPreviewFailedMessage: "无法读取该文本内容，可能是远程文件不可访问或响应状态异常。",
+    textOpenOriginal: "打开原文件",
+    officeLegacyConversionTitle: "Office 转换提示",
+    officeLegacyBinaryNotice:
+      "属于旧版 Microsoft Office 二进制格式，浏览器内无法高保真解析；当前仅展示可信文本片段和结构指纹，完整排版建议接入 LibreOffice/OnlyOffice 服务端转换为 PDF/HTML。",
+    officeLegacyMetaFormatType: "格式类型",
+    officeLegacyMetaFileStructure: "文件结构",
+    officeLegacyOleDetected: "检测到 OLE Compound File 签名",
+    officeLegacyOleMissing: "未检测到标准 OLE 签名，按原始二进制尝试提取",
+    officeLegacyMetaTextFragments: "文本片段",
+    officeLegacyTextFragmentCount: "{count} 段",
+    officeLegacyMetaParseStatus: "解析状态",
+    officeLegacyReadableFragments: "可读文本片段",
+    officeLegacyNoText: "未提取到稳定可读文本。该文件可能经过压缩、加密，或文本编码无法在浏览器端可靠识别；请使用服务端 LibreOffice/OnlyOffice 转换后预览。",
+    officeLegacyWordParseFailed: "Word 二进制解析失败：{message}",
+    officeSheetParseFailed: "表格解析失败：{message}",
+    officeUnsupportedTitle: "Office 基础预览",
+    officeUnsupportedLegacyMessage:
+      "该格式属于老二进制或专有格式，浏览器内无法可靠解析；建议接入 LibreOffice/OnlyOffice 服务端转换为 PDF/HTML 后预览。",
+    officeUnsupportedGenericMessage: "该格式通常需要服务端转换或专用解析器才能高保真预览。",
+    officeUnsupportedIntro: "已进入 Office 插件。{message}",
+    officeUnsupportedSupportedFormats:
+      "当前版本优先支持 docx、rtf、odt/fodt、xlsx/xls/csv/ods、pptx/ppsx、odp/fodp 的基础内容预览。",
+    officeErrorWithMessage: "解析器返回：{message}",
+    officeErrorWithoutMessage: "解析器未返回具体错误信息。"
   },
   "en-US": {
     loading: "Loading preview...",
@@ -31,7 +67,43 @@ export const defaultMessages: Record<PreviewLocale, PreviewMessages> = {
     size: "Size",
     source: "Source",
     remoteUrl: "Remote URL",
-    localFile: "Local or in-memory file"
+    localFile: "Local or in-memory file",
+    textPlainLanguage: "plain text",
+    textLineCount: "{count} lines",
+    textWrap: "Wrap",
+    textCopy: "Copy",
+    textCopied: "Copied",
+    textCopyFailed: "Copy failed",
+    textDownload: "Download",
+    textDownloadReady: "Download ready",
+    textLargeFileNotice: "Large file, showing the first {size}. Copy and download still use the full content.",
+    textHighlightSkipped: "Large content, syntax highlighting was skipped to keep scrolling smooth.",
+    textPreviewFailedTitle: "Text preview failed",
+    textPreviewFailedMessage: "Unable to read this text content. The remote file may be unreachable or returned an invalid response.",
+    textOpenOriginal: "Open original file",
+    officeLegacyConversionTitle: "Office conversion guidance",
+    officeLegacyBinaryNotice:
+      "belongs to a legacy Microsoft Office binary format that cannot be rendered with high fidelity in the browser. The preview shows trusted text fragments and structural fingerprints; use a LibreOffice/OnlyOffice server conversion to PDF/HTML for complete layout fidelity.",
+    officeLegacyMetaFormatType: "Format type",
+    officeLegacyMetaFileStructure: "File structure",
+    officeLegacyOleDetected: "OLE Compound File signature detected",
+    officeLegacyOleMissing: "No standard OLE signature detected; extracting from raw binary data",
+    officeLegacyMetaTextFragments: "Text fragments",
+    officeLegacyTextFragmentCount: "{count} fragments",
+    officeLegacyMetaParseStatus: "Parse status",
+    officeLegacyReadableFragments: "Readable text fragments",
+    officeLegacyNoText: "No stable readable text was extracted. The file may be compressed, encrypted, or use text encoding that cannot be reliably recognized in the browser; use LibreOffice/OnlyOffice server conversion before previewing.",
+    officeLegacyWordParseFailed: "Word binary parse failed: {message}",
+    officeSheetParseFailed: "Spreadsheet parse failed: {message}",
+    officeUnsupportedTitle: "Office basic preview",
+    officeUnsupportedLegacyMessage:
+      "This is a legacy binary or proprietary format that cannot be reliably parsed in the browser; convert it to PDF/HTML through LibreOffice/OnlyOffice on the server before previewing.",
+    officeUnsupportedGenericMessage: "This format usually needs server-side conversion or a dedicated parser for high-fidelity preview.",
+    officeUnsupportedIntro: "is handled by the Office plugin. {message}",
+    officeUnsupportedSupportedFormats:
+      "This version prioritizes basic previews for docx, rtf, odt/fodt, xlsx/xls/csv/ods, pptx/ppsx, and odp/fodp files.",
+    officeErrorWithMessage: "Parser returned: {message}",
+    officeErrorWithoutMessage: "Parser did not return a specific error."
   }
 };
 
@@ -40,4 +112,8 @@ export function resolveMessages(options: Pick<PreviewOptions, "locale" | "messag
     ...defaultMessages[options.locale || "zh-CN"],
     ...options.messages
   };
+}
+
+export function formatPreviewMessage(template: string, values: Record<string, string | number>): string {
+  return template.replace(/\{(\w+)\}/g, (match, key: string) => String(values[key] ?? match));
 }

--- a/packages/core/src/plugins/archive.test.ts
+++ b/packages/core/src/plugins/archive.test.ts
@@ -179,6 +179,61 @@ describe("archivePlugin", () => {
     expect(visibleText(container)).not.toContain("总解压大小17 B");
   });
 
+  it("keeps the archive summary visible when a zip only contains directories", async () => {
+    const zip = new JSZip();
+    zip.folder("empty");
+    const buffer = await zip.generateAsync({ type: "arraybuffer" });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    createViewer({
+      container,
+      file: buffer,
+      fileName: "folders-only.zip",
+      plugins: [archivePlugin()]
+    });
+
+    await waitFor(() => Boolean(container.querySelector(".ofv-archive-info")));
+
+    expect(container.querySelector(".ofv-archive-item")).toBeNull();
+    const info = container.querySelector<HTMLElement>(".ofv-archive-info");
+    expect(info?.hidden).toBe(false);
+    expect(info?.getAttribute("aria-hidden")).toBeNull();
+    expect(info?.style.display).not.toBe("none");
+    const text = visibleText(container);
+    expect(text).toContain("包含文件数： 0 个");
+    expect(text).toContain("包含目录数： 1 个");
+    expect(text).toContain("压缩包内没有可预览的文件。");
+  });
+
+  it("keeps the archive summary visible when a zip has no entries", async () => {
+    const zip = new JSZip();
+    const buffer = await zip.generateAsync({ type: "arraybuffer" });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    createViewer({
+      container,
+      file: buffer,
+      fileName: "empty.zip",
+      plugins: [archivePlugin()]
+    });
+
+    await waitFor(() => Boolean(container.querySelector(".ofv-archive-info")));
+
+    expect(container.querySelector(".ofv-archive-item")).toBeNull();
+    const info = container.querySelector<HTMLElement>(".ofv-archive-info");
+    expect(info?.hidden).toBe(false);
+    expect(info?.getAttribute("aria-hidden")).toBeNull();
+    expect(info?.style.display).not.toBe("none");
+    const text = visibleText(container);
+    expect(text).toContain("包含文件数： 0 个");
+    expect(text).toContain("包含目录数： 0 个");
+    expect(text).toContain("压缩包内没有可预览的文件。");
+  });
+
   it("keeps archive sidebar collapsible and auto-collapses after selecting files in narrow containers", async () => {
     const zip = new JSZip();
     for (let index = 0; index < 30; index += 1) {

--- a/packages/core/src/plugins/archive.ts
+++ b/packages/core/src/plugins/archive.ts
@@ -263,11 +263,13 @@ export function archivePlugin(): PreviewPlugin {
       });
 
       // Render default metadata summary
-      const showDefaultSummary = () => {
+      const showDefaultSummary = (isSupplemental = true) => {
         mainPanel.replaceChildren();
         const summary = document.createElement("div");
         summary.className = "ofv-archive-info";
-        hideSupplementalInfo(summary);
+        if (isSupplemental) {
+          hideSupplementalInfo(summary);
+        }
         
         const heading = document.createElement("h3");
         heading.textContent = ctx.file.name;
@@ -281,16 +283,19 @@ export function archivePlugin(): PreviewPlugin {
         appendArchiveInfo(info, "格式类型", `.${ext.toUpperCase()} 压缩文件`);
         appendArchiveInfo(info, "包含文件数", `${fileCount} 个`);
         appendArchiveInfo(info, "包含目录数", `${dirCount} 个`);
-        appendArchiveInfo(info, "操作提示", "请点击左侧栏中的文件进行联动预览。");
+        appendArchiveInfo(
+          info,
+          "操作提示",
+          fileCount === 0 ? "压缩包内没有可预览的文件。" : "请点击左侧栏中的文件进行联动预览。"
+        );
         
         summary.append(heading, info, createArchiveSummary(archiveEntries));
         mainPanel.append(summary);
       };
 
-      showDefaultSummary();
-
       // Filter and render items (max 500 to keep DOM lightweight)
       const visibleEntries = archiveEntries.filter(e => !e.dir).slice(0, 500);
+      showDefaultSummary(visibleEntries.length > 0);
       let destroyed = false;
       let renderToken = 0;
 

--- a/packages/core/src/plugins/office.test.ts
+++ b/packages/core/src/plugins/office.test.ts
@@ -1285,6 +1285,27 @@ describe("officePlugin", () => {
     expect(container.textContent).toContain("Budget 2026");
   });
 
+  it("localizes legacy Office conversion guidance", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    createViewer({
+      container,
+      file: createLegacyBinaryBlob(["Quarterly roadmap", "Budget 2026"]),
+      fileName: "legacy.doc",
+      locale: "en-US",
+      plugins: [officePlugin()]
+    });
+
+    await waitFor(() => Boolean(container.querySelector(".ofv-office")));
+
+    expect(container.textContent).toContain("Office conversion guidance");
+    expect(container.textContent).toContain("belongs to a legacy Microsoft Office binary format");
+    expect(container.textContent).toContain("Readable text fragments");
+    expect(container.textContent).toContain("Quarterly roadmap");
+    expect(container.textContent).not.toContain("Office 转换提示");
+  });
+
   it("renders real Word 97-2003 .doc files through the built-in parser when a sample is available", async () => {
     const samplePath = "/Users/kuangkuang/Desktop/sample5.doc";
     if (!existsSync(samplePath)) {

--- a/packages/core/src/plugins/office.ts
+++ b/packages/core/src/plugins/office.ts
@@ -1,7 +1,8 @@
 import JSZip from "jszip";
 import DOMPurify from "dompurify";
 import type { WorkBook } from "xlsx";
-import type { PreviewCommand, PreviewContext, PreviewFit, PreviewInstance, PreviewPlugin } from "../types";
+import { formatPreviewMessage } from "../messages";
+import type { PreviewCommand, PreviewContext, PreviewFit, PreviewInstance, PreviewMessages, PreviewPlugin } from "../types";
 import { createPanel, createSection, decodeTextBuffer, getInitialZoom, readArrayBuffer, resolveFormat } from "./utils";
 import { renderPdfDocumentPreview, type PdfPluginOptions } from "./pdf";
 import { parseLegacyWordDocument, renderLegacyWordDocument } from "./msdoc";
@@ -169,7 +170,7 @@ export function officePlugin(options: OfficePluginOptions = {}): PreviewPlugin {
       } else if (packageFormat === "docx" && !fileIsDocx(extension)) {
         disposeDocxFit = await renderDocx(panel, arrayBuffer, ctx.options.fit);
       } else if (packageFormat === "xlsx" && !sheetExtensions.has(extension)) {
-        await renderSheet(panel, arrayBuffer, "xlsx");
+        await renderSheet(panel, arrayBuffer, "xlsx", ctx.options.messages);
       } else if (packageFormat === "pptx" && !["pptx", "pptm", "ppsx", "ppsm", "potx", "potm"].includes(extension)) {
         await renderPptx(panel, arrayBuffer);
       } else if (fileIsDocx(extension)) {
@@ -182,10 +183,13 @@ export function officePlugin(options: OfficePluginOptions = {}): PreviewPlugin {
         renderOpenDocumentXml(panel, "FODT 文档", await readTextFromBuffer(arrayBuffer));
       } else if (extension === "fods") {
         renderFlatOds(panel, await readTextFromBuffer(arrayBuffer));
-      } else if (packagedOfficeCandidates.has(extension) && (await renderPackagedOfficePreview(panel, arrayBuffer, extension, ctx.options.fit))) {
+      } else if (
+        packagedOfficeCandidates.has(extension) &&
+        (await renderPackagedOfficePreview(panel, arrayBuffer, extension, ctx.options.fit, ctx.options.messages))
+      ) {
         // Rendered by package sniffing.
       } else if (sheetExtensions.has(extension)) {
-        await renderSheet(panel, arrayBuffer, extension);
+        await renderSheet(panel, arrayBuffer, extension, ctx.options.messages);
       } else if (["pptx", "pptm", "ppsx", "ppsm", "potx", "potm"].includes(extension)) {
         await renderPptx(panel, arrayBuffer);
       } else if (extension === "odp") {
@@ -193,11 +197,11 @@ export function officePlugin(options: OfficePluginOptions = {}): PreviewPlugin {
       } else if (extension === "fodp") {
         renderOpenDocumentPresentationXml(panel, await readTextFromBuffer(arrayBuffer));
       } else if (extension === "doc" || extension === "dot") {
-        renderLegacyWordBinary(panel, extension, arrayBuffer);
+        renderLegacyWordBinary(panel, extension, arrayBuffer, ctx.options.messages);
       } else if (isLegacyOfficeBinary(extension)) {
-        renderLegacyOfficeBinary(panel, extension, arrayBuffer);
+        renderLegacyOfficeBinary(panel, extension, arrayBuffer, ctx.options.messages);
       } else {
-        renderUnsupportedOffice(panel, extension || ctx.file.extension || "office");
+        renderUnsupportedOffice(panel, extension || ctx.file.extension || "office", ctx.options.messages);
       }
 
       const controller = createOfficeZoomController(panel, ctx);
@@ -1837,7 +1841,8 @@ function renderPlainDocument(panel: HTMLElement, title: string, text: string): v
 async function renderSheet(
   panel: HTMLElement,
   arrayBuffer: ArrayBuffer,
-  extension: string
+  extension: string,
+  messages: PreviewMessages
 ): Promise<void> {
   const xlsx = await import("xlsx");
   let workbook: WorkBook;
@@ -1854,10 +1859,16 @@ async function renderSheet(
         : (xlsx.read(arrayBuffer, { type: "array", cellDates: true, cellNF: true, cellStyles: true }) as WorkBook);
   } catch (error) {
     if (isLegacyOfficeBinary(extension)) {
-      renderLegacyOfficeBinary(panel, extension, arrayBuffer, `表格解析失败：${normalizeOfficeError(error)}`);
+      renderLegacyOfficeBinary(
+        panel,
+        extension,
+        arrayBuffer,
+        messages,
+        formatPreviewMessage(messages.officeSheetParseFailed, { message: normalizeOfficeError(error, messages) })
+      );
       return;
     }
-    renderSheetFallback(panel, extension, normalizeOfficeError(error));
+    renderSheetFallback(panel, extension, normalizeOfficeError(error, messages));
     return;
   }
   const chartPreviews = await readWorkbookCharts(arrayBuffer).catch(() => []);
@@ -3488,7 +3499,8 @@ async function renderPackagedOfficePreview(
   panel: HTMLElement,
   arrayBuffer: ArrayBuffer,
   extension: string,
-  fit: PreviewFit
+  fit: PreviewFit,
+  messages: PreviewMessages
 ): Promise<boolean> {
   let zip: JSZip;
   try {
@@ -3507,7 +3519,7 @@ async function renderPackagedOfficePreview(
   }
 
   if (hasEntry("xl/workbook.xml")) {
-    await renderSheet(panel, arrayBuffer, extension);
+    await renderSheet(panel, arrayBuffer, extension, messages);
     return true;
   }
 
@@ -4001,36 +4013,56 @@ function legacyOfficeFormatLabel(extension: string): string {
   return "PowerPoint Binary File Format";
 }
 
-function renderLegacyWordBinary(panel: HTMLElement, extension: string, arrayBuffer: ArrayBuffer): void {
+function renderLegacyWordBinary(
+  panel: HTMLElement,
+  extension: string,
+  arrayBuffer: ArrayBuffer,
+  messages: PreviewMessages
+): void {
   try {
     renderLegacyWordDocument(panel, parseLegacyWordDocument(arrayBuffer));
   } catch (error) {
-    renderLegacyOfficeBinary(panel, extension, arrayBuffer, `Word 二进制解析失败：${normalizeOfficeError(error)}`);
+    renderLegacyOfficeBinary(
+      panel,
+      extension,
+      arrayBuffer,
+      messages,
+      formatPreviewMessage(messages.officeLegacyWordParseFailed, { message: normalizeOfficeError(error, messages) })
+    );
   }
 }
 
-function renderLegacyOfficeBinary(panel: HTMLElement, extension: string, arrayBuffer: ArrayBuffer, parseError?: string): void {
+function renderLegacyOfficeBinary(
+  panel: HTMLElement,
+  extension: string,
+  arrayBuffer: ArrayBuffer,
+  messages: PreviewMessages,
+  parseError?: string
+): void {
   const fragments = extractLegacyOfficeText(arrayBuffer);
   panel.replaceChildren();
-  const section = createSection("Office 转换提示");
+  const section = createSection(messages.officeLegacyConversionTitle);
   section.classList.add("ofv-office-conversion");
   const format = document.createElement("p");
   const strong = document.createElement("strong");
   strong.textContent = `.${extension}`;
-  format.append(
-    strong,
-    document.createTextNode(
-      " 属于旧版 Microsoft Office 二进制格式，浏览器内无法高保真解析；当前仅展示可信文本片段和结构指纹，完整排版建议接入 LibreOffice/OnlyOffice 服务端转换为 PDF/HTML。"
-    )
-  );
+  format.append(strong, document.createTextNode(" "), document.createTextNode(messages.officeLegacyBinaryNotice));
 
   const meta = document.createElement("dl");
   meta.className = "ofv-office-binary-meta";
-  appendOfficeBinaryMeta(meta, "格式类型", legacyOfficeFormatLabel(extension));
-  appendOfficeBinaryMeta(meta, "文件结构", hasOleSignature(arrayBuffer) ? "检测到 OLE Compound File 签名" : "未检测到标准 OLE 签名，按原始二进制尝试提取");
-  appendOfficeBinaryMeta(meta, "文本片段", `${fragments.length} 段`);
+  appendOfficeBinaryMeta(meta, messages.officeLegacyMetaFormatType, legacyOfficeFormatLabel(extension));
+  appendOfficeBinaryMeta(
+    meta,
+    messages.officeLegacyMetaFileStructure,
+    hasOleSignature(arrayBuffer) ? messages.officeLegacyOleDetected : messages.officeLegacyOleMissing
+  );
+  appendOfficeBinaryMeta(
+    meta,
+    messages.officeLegacyMetaTextFragments,
+    formatPreviewMessage(messages.officeLegacyTextFragmentCount, { count: fragments.length.toLocaleString() })
+  );
   if (parseError) {
-    appendOfficeBinaryMeta(meta, "解析状态", parseError);
+    appendOfficeBinaryMeta(meta, messages.officeLegacyMetaParseStatus, parseError);
   }
 
   section.append(format, meta);
@@ -4039,7 +4071,7 @@ function renderLegacyOfficeBinary(panel: HTMLElement, extension: string, arrayBu
     const article = document.createElement("article");
     article.className = "ofv-document ofv-office-binary-fragments";
     const heading = document.createElement("h4");
-    heading.textContent = "可读文本片段";
+    heading.textContent = messages.officeLegacyReadableFragments;
     article.append(heading);
     for (const fragment of fragments.slice(0, 80)) {
       const paragraph = document.createElement("p");
@@ -4050,7 +4082,7 @@ function renderLegacyOfficeBinary(panel: HTMLElement, extension: string, arrayBu
   } else {
     const empty = document.createElement("p");
     empty.className = "ofv-office-binary-empty";
-    empty.textContent = "未提取到稳定可读文本。该文件可能经过压缩、加密，或文本编码无法在浏览器端可靠识别；请使用服务端 LibreOffice/OnlyOffice 转换后预览。";
+    empty.textContent = messages.officeLegacyNoText;
     section.append(empty);
   }
 
@@ -4065,28 +4097,34 @@ function appendOfficeBinaryMeta(list: HTMLDListElement, label: string, value: st
   list.append(term, detail);
 }
 
-function renderUnsupportedOffice(panel: HTMLElement, extension: string): void {
+function renderUnsupportedOffice(panel: HTMLElement, extension: string, messages: PreviewMessages): void {
   const legacyBinary = new Set(["doc", "dot", "wps", "ppt", "pps", "key", "dps"]);
   const message = legacyBinary.has(extension)
-    ? "该格式属于老二进制或专有格式，浏览器内无法可靠解析；建议接入 LibreOffice/OnlyOffice 服务端转换为 PDF/HTML 后预览。"
-    : "该格式通常需要服务端转换或专用解析器才能高保真预览。";
+    ? messages.officeUnsupportedLegacyMessage
+    : messages.officeUnsupportedGenericMessage;
   panel.replaceChildren();
-  const section = createSection("Office 基础预览");
+  const section = createSection(messages.officeUnsupportedTitle);
   const format = document.createElement("p");
   const strong = document.createElement("strong");
   strong.textContent = `.${extension}`;
-  format.append(strong, document.createTextNode(` 已进入 Office 插件。${message}`));
+  format.append(
+    strong,
+    document.createTextNode(" "),
+    document.createTextNode(formatPreviewMessage(messages.officeUnsupportedIntro, { message }))
+  );
 
   const support = document.createElement("p");
-  support.textContent = "当前版本优先支持 docx、rtf、odt/fodt、xlsx/xls/csv/ods、pptx/ppsx、odp/fodp 的基础内容预览。";
+  support.textContent = messages.officeUnsupportedSupportedFormats;
 
   section.append(format, support);
   panel.append(section);
 }
 
-function normalizeOfficeError(error: unknown): string {
+function normalizeOfficeError(error: unknown, messages: PreviewMessages): string {
   const message = error instanceof Error ? error.message : String(error || "");
-  return message ? `解析器返回：${message}` : "解析器未返回具体错误信息。";
+  return message
+    ? formatPreviewMessage(messages.officeErrorWithMessage, { message })
+    : messages.officeErrorWithoutMessage;
 }
 
 function extractLegacyOfficeText(arrayBuffer: ArrayBuffer): string[] {

--- a/packages/core/src/plugins/render-smoke.test.ts
+++ b/packages/core/src/plugins/render-smoke.test.ts
@@ -1184,7 +1184,7 @@ function smokeCases(): SmokeCase[] {
       fileName: "notes.txt",
       plugins: [textPlugin()],
       selector: ".ofv-code-container.is-wrapped",
-      text: "plain text"
+      text: "纯文本"
     },
     {
       name: "extensionless project file",

--- a/packages/core/src/plugins/text.test.ts
+++ b/packages/core/src/plugins/text.test.ts
@@ -143,6 +143,29 @@ describe("textPlugin", () => {
     expect(onError).not.toHaveBeenCalled();
   });
 
+  it("localizes the remote text fallback", async () => {
+    const container = document.createElement("div");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve({ ok: false, status: 500 } as Response))
+    );
+    document.body.append(container);
+
+    createViewer({
+      container,
+      file: "https://example.com/error.txt",
+      fileName: "error.txt",
+      locale: "en-US",
+      plugins: [textPlugin()]
+    });
+
+    await waitFor(() => Boolean(container.querySelector(".ofv-fallback")));
+
+    expect(container.textContent).toContain("Text preview failed");
+    expect(container.textContent).toContain("Open original file");
+    expect(container.textContent).not.toContain("文本预览失败");
+  });
+
   it("renders remote text sources and keeps shared toolbar commands working", async () => {
     const container = document.createElement("div");
     vi.stubGlobal(
@@ -209,6 +232,7 @@ describe("textPlugin", () => {
     createViewer({
       container,
       file: new Blob(["const answer = 42;"], { type: "application/javascript" }),
+      locale: "en-US",
       plugins: [textPlugin()]
     });
 
@@ -398,6 +422,7 @@ describe("textPlugin", () => {
       container,
       file: new Blob([text], { type }),
       fileName: name,
+      locale: "en-US",
       plugins: [textPlugin()]
     });
 
@@ -450,6 +475,7 @@ describe("textPlugin", () => {
       container,
       file: new Blob(["const one = 1;\nconst two = 2;"], { type: "text/javascript" }),
       fileName: "sample.mjs",
+      locale: "en-US",
       plugins: [textPlugin()]
     });
 
@@ -476,6 +502,7 @@ describe("textPlugin", () => {
       container,
       file: new Blob(["Open File Viewer\n\n请选择一个本地文件。"], { type: "text/plain" }),
       fileName: "welcome.txt",
+      locale: "en-US",
       plugins: [textPlugin()]
     });
 
@@ -525,6 +552,7 @@ describe("textPlugin", () => {
       container,
       file: new Blob(["line one\nline two"], { type: "text/plain" }),
       fileName: "notes.txt",
+      locale: "en-US",
       plugins: [textPlugin()]
     });
 
@@ -539,6 +567,46 @@ describe("textPlugin", () => {
     await waitFor(() => container.querySelector(".ofv-code-status")?.textContent === "Copied");
   });
 
+  it("uses custom messages for code preview controls and status text", async () => {
+    const container = document.createElement("div");
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    vi.stubGlobal("navigator", { clipboard: { writeText } });
+    document.body.append(container);
+
+    createViewer({
+      container,
+      file: new Blob(["one\ntwo"], { type: "text/plain" }),
+      fileName: "custom.txt",
+      plugins: [textPlugin()],
+      messages: {
+        textPlainLanguage: "raw text",
+        textLineCount: "{count} rows",
+        textWrap: "Fold",
+        textCopy: "Duplicate",
+        textCopied: "Done",
+        textDownload: "Save"
+      }
+    });
+
+    await waitFor(() => Boolean(container.querySelector(".ofv-code-container code")));
+
+    expect(container.querySelector(".ofv-code-title")?.textContent).toContain("raw text");
+    expect(container.querySelector(".ofv-code-title")?.textContent).toContain("2 rows");
+    expect(Array.from(container.querySelectorAll(".ofv-code-action")).map((button) => button.textContent)).toEqual([
+      "Fold",
+      "Duplicate",
+      "Save"
+    ]);
+
+    const copy = Array.from(container.querySelectorAll<HTMLButtonElement>(".ofv-code-action")).find(
+      (button) => button.textContent === "Duplicate"
+    );
+    copy?.click();
+
+    await waitFor(() => writeText.mock.calls.length > 0);
+    await waitFor(() => container.querySelector(".ofv-code-status")?.textContent === "Done");
+  });
+
   it("downloads the full text from the preview action", async () => {
     const container = document.createElement("div");
     const createObjectURL = vi.fn(() => "blob:preview");
@@ -551,6 +619,7 @@ describe("textPlugin", () => {
       container,
       file: new Blob(["download me"], { type: "text/plain" }),
       fileName: "download.txt",
+      locale: "en-US",
       plugins: [textPlugin()]
     });
 
@@ -586,7 +655,7 @@ describe("textPlugin", () => {
     expect(container.querySelector(".ofv-code-container code")?.textContent).not.toContain("TAIL");
 
     const copy = Array.from(container.querySelectorAll<HTMLButtonElement>(".ofv-code-action")).find(
-      (button) => button.textContent === "Copy"
+      (button) => button.textContent === "复制"
     );
     copy?.click();
     await waitFor(() => writeText.mock.calls.length > 0);

--- a/packages/core/src/plugins/text.ts
+++ b/packages/core/src/plugins/text.ts
@@ -1,6 +1,7 @@
 /// <reference path="../shims-text.d.ts" />
 import { isTextLike } from "../detect";
-import type { PreviewCommand, PreviewContext, PreviewPlugin } from "../types";
+import { formatPreviewMessage } from "../messages";
+import type { PreviewCommand, PreviewContext, PreviewMessages, PreviewPlugin } from "../types";
 import { decodeTextBuffer, getInitialZoom } from "./utils";
 
 const langMap: Record<string, string> = {
@@ -174,7 +175,7 @@ export function textPlugin(): PreviewPlugin {
       const isMarkdown = lang === "markdown";
       const text = await readText(ctx.file.source).catch((error: unknown) => undefined);
       if (text === undefined) {
-        const fallback = createTextFallback(ctx.file.name, ctx.file.url);
+        const fallback = createTextFallback(ctx.file.name, ctx.options.messages, ctx.file.url);
         ctx.viewport.classList.add("ofv-center");
         ctx.viewport.append(fallback);
         return {
@@ -362,10 +363,11 @@ export function textPlugin(): PreviewPlugin {
       title.className = "ofv-code-title";
       const fileName = document.createElement("strong");
       fileName.textContent = ctx.file.name;
+      const messages = ctx.options.messages;
       const meta = document.createElement("span");
       meta.textContent = [
-        lang === "none" ? "plain text" : lang,
-        `${totalLines.toLocaleString()} lines`,
+        lang === "none" ? messages.textPlainLanguage : lang,
+        formatPreviewMessage(messages.textLineCount, { count: totalLines.toLocaleString() }),
         formatBytes(ctx.file.size ?? (ctx.file.source instanceof Blob ? ctx.file.source.size : text.length))
       ].join(" · ");
       title.append(fileName, meta);
@@ -380,7 +382,7 @@ export function textPlugin(): PreviewPlugin {
       const wrapButton = document.createElement("button");
       wrapButton.type = "button";
       wrapButton.className = "ofv-code-action";
-      wrapButton.textContent = "Wrap";
+      wrapButton.textContent = messages.textWrap;
       wrapButton.setAttribute("aria-pressed", String(defaultWrapped));
       wrapButton.addEventListener("click", () => {
         const wrapped = wrapper.classList.toggle("is-wrapped");
@@ -390,14 +392,14 @@ export function textPlugin(): PreviewPlugin {
       const copyButton = document.createElement("button");
       copyButton.type = "button";
       copyButton.className = "ofv-code-action";
-      copyButton.textContent = "Copy";
+      copyButton.textContent = messages.textCopy;
       copyButton.addEventListener("click", async () => {
         copyButton.disabled = true;
         try {
           await copyToClipboard(text);
-          status.textContent = "Copied";
+          status.textContent = messages.textCopied;
         } catch {
-          status.textContent = "Copy failed";
+          status.textContent = messages.textCopyFailed;
         } finally {
           copyButton.disabled = false;
         }
@@ -406,10 +408,10 @@ export function textPlugin(): PreviewPlugin {
       const downloadButton = document.createElement("button");
       downloadButton.type = "button";
       downloadButton.className = "ofv-code-action";
-      downloadButton.textContent = "Download";
+      downloadButton.textContent = messages.textDownload;
       downloadButton.addEventListener("click", () => {
         downloadText(ctx.file.name, text);
-        status.textContent = "Download ready";
+        status.textContent = messages.textDownloadReady;
       });
 
       actions.append(wrapButton, copyButton, downloadButton, status);
@@ -440,13 +442,13 @@ export function textPlugin(): PreviewPlugin {
       if (truncated) {
         const notice = document.createElement("div");
         notice.className = "ofv-code-notice";
-        notice.textContent = `文件较大，当前展示前 ${formatBytes(codeText.length)}，复制和下载仍会使用完整内容。`;
+        notice.textContent = formatPreviewMessage(messages.textLargeFileNotice, { size: formatBytes(codeText.length) });
         wrapper.append(notice);
       }
       if (!shouldHighlight) {
         const notice = document.createElement("div");
         notice.className = "ofv-code-notice";
-        notice.textContent = "内容较大，已跳过语法高亮以保持滚动流畅。";
+        notice.textContent = messages.textHighlightSkipped;
         wrapper.append(notice);
       }
       wrapper.appendChild(body);
@@ -529,22 +531,22 @@ function normalizeFileName(name: string): string {
   return baseName.toLowerCase();
 }
 
-function createTextFallback(fileName: string, url?: string): HTMLElement {
+function createTextFallback(fileName: string, messages: PreviewMessages, url?: string): HTMLElement {
   const fallback = document.createElement("div");
   fallback.className = "ofv-fallback";
 
   const title = document.createElement("strong");
-  title.textContent = "文本预览失败";
+  title.textContent = messages.textPreviewFailedTitle;
 
   const meta = document.createElement("span");
-  meta.textContent = "无法读取该文本内容，可能是远程文件不可访问或响应状态异常。";
+  meta.textContent = messages.textPreviewFailedMessage;
 
   fallback.append(title, meta);
   if (url) {
     const download = document.createElement("a");
     download.href = url;
     download.download = fileName;
-    download.textContent = "打开原文件";
+    download.textContent = messages.textOpenOriginal;
     fallback.append(download);
   }
   return fallback;

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -134,6 +134,39 @@ export interface PreviewMessages {
   source: string;
   remoteUrl: string;
   localFile: string;
+  textPlainLanguage: string;
+  textLineCount: string;
+  textWrap: string;
+  textCopy: string;
+  textCopied: string;
+  textCopyFailed: string;
+  textDownload: string;
+  textDownloadReady: string;
+  textLargeFileNotice: string;
+  textHighlightSkipped: string;
+  textPreviewFailedTitle: string;
+  textPreviewFailedMessage: string;
+  textOpenOriginal: string;
+  officeLegacyConversionTitle: string;
+  officeLegacyBinaryNotice: string;
+  officeLegacyMetaFormatType: string;
+  officeLegacyMetaFileStructure: string;
+  officeLegacyOleDetected: string;
+  officeLegacyOleMissing: string;
+  officeLegacyMetaTextFragments: string;
+  officeLegacyTextFragmentCount: string;
+  officeLegacyMetaParseStatus: string;
+  officeLegacyReadableFragments: string;
+  officeLegacyNoText: string;
+  officeLegacyWordParseFailed: string;
+  officeSheetParseFailed: string;
+  officeUnsupportedTitle: string;
+  officeUnsupportedLegacyMessage: string;
+  officeUnsupportedGenericMessage: string;
+  officeUnsupportedIntro: string;
+  officeUnsupportedSupportedFormats: string;
+  officeErrorWithMessage: string;
+  officeErrorWithoutMessage: string;
 }
 
 export interface PreviewContext {

--- a/packages/core/src/viewer.test.ts
+++ b/packages/core/src/viewer.test.ts
@@ -578,6 +578,61 @@ describe("createViewer", () => {
     viewer.destroy();
   });
 
+  it("ignores hidden preview text when searching", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    const plugin: PreviewPlugin = {
+      name: "hidden-search",
+      match: () => true,
+      render(ctx) {
+        const visible = document.createElement("p");
+        visible.className = "visible-source";
+        visible.textContent = "visible needle";
+
+        const hidden = document.createElement("section");
+        hidden.className = "hidden-source";
+        hidden.hidden = true;
+        hidden.setAttribute("aria-hidden", "true");
+        hidden.style.display = "none";
+        const hiddenText = document.createElement("span");
+        hiddenText.textContent = "hidden needle";
+        hidden.append(hiddenText);
+
+        ctx.viewport.append(visible, hidden);
+        return { destroy: vi.fn() };
+      }
+    };
+
+    const viewer = createViewer({
+      container,
+      file: new Blob(["hello"], { type: "text/plain" }),
+      fileName: "hello.txt",
+      toolbar: true,
+      plugins: [plugin]
+    });
+
+    await waitFor(() => container.textContent?.includes("visible needle") === true);
+
+    const searchInput = container.querySelector<HTMLInputElement>('input[aria-label="Search preview text"]');
+    expect(searchInput).not.toBeNull();
+    searchInput!.value = "needle";
+    searchInput!.dispatchEvent(new InputEvent("input", { bubbles: true }));
+
+    expect(container.querySelector(".ofv-toolbar-search-count")?.textContent).toBe("1");
+    expect(container.querySelectorAll("mark.ofv-search-match")).toHaveLength(1);
+    expect(container.querySelector(".visible-source mark.ofv-search-match")?.textContent).toBe("needle");
+    expect(container.querySelector(".hidden-source mark.ofv-search-match")).toBeNull();
+
+    searchInput!.value = "hidden";
+    searchInput!.dispatchEvent(new InputEvent("input", { bubbles: true }));
+
+    expect(container.querySelector(".ofv-toolbar-search-count")?.textContent).toBe("0");
+    expect(container.querySelectorAll("mark.ofv-search-match")).toHaveLength(0);
+
+    viewer.destroy();
+  });
+
   it("resets command support and zoom state when navigating between different preview types", async () => {
     const container = document.createElement("div");
     document.body.append(container);

--- a/packages/core/src/viewer.test.ts
+++ b/packages/core/src/viewer.test.ts
@@ -46,6 +46,37 @@ describe("createViewer", () => {
     expect(container.childElementCount).toBe(0);
   });
 
+  it("supports multiple className tokens on the viewer container", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    const viewer = createViewer({
+      container,
+      file: new Blob(["hello"], { type: "text/plain" }),
+      fileName: "hello.txt",
+      className: "viewer-shell viewer-wide",
+      plugins: [
+        {
+          name: "test",
+          match: (file) => file.extension === "txt",
+          render(ctx) {
+            ctx.viewport.textContent = ctx.file.name;
+            return { destroy: vi.fn() };
+          }
+        }
+      ]
+    });
+
+    expect(container.classList.contains("viewer-shell")).toBe(true);
+    expect(container.classList.contains("viewer-wide")).toBe(true);
+    expect(container.classList.contains("ofv-root")).toBe(true);
+
+    viewer.destroy();
+    expect(container.classList.contains("viewer-shell")).toBe(false);
+    expect(container.classList.contains("viewer-wide")).toBe(false);
+    expect(container.classList.contains("ofv-root")).toBe(false);
+  });
+
   it("disables toolbar commands unsupported by the active preview", async () => {
     const container = document.createElement("div");
     document.body.append(container);

--- a/packages/core/src/viewer.ts
+++ b/packages/core/src/viewer.ts
@@ -1036,6 +1036,9 @@ function collectSearchableTextNodes(root: HTMLElement): Text[] {
       if (["SCRIPT", "STYLE", "TEXTAREA", "INPUT", "BUTTON"].includes(parent.tagName)) {
         return NodeFilter.FILTER_REJECT;
       }
+      if (hasHiddenSearchAncestor(parent, root)) {
+        return NodeFilter.FILTER_REJECT;
+      }
       return NodeFilter.FILTER_ACCEPT;
     }
   });
@@ -1046,6 +1049,25 @@ function collectSearchableTextNodes(root: HTMLElement): Text[] {
     current = walker.nextNode();
   }
   return nodes;
+}
+
+function hasHiddenSearchAncestor(element: HTMLElement, root: HTMLElement): boolean {
+  let current: HTMLElement | null = element;
+  while (current) {
+    if (
+      current.hidden ||
+      current.getAttribute("aria-hidden") === "true" ||
+      current.style.display === "none" ||
+      current.style.visibility === "hidden"
+    ) {
+      return true;
+    }
+    if (current === root) {
+      break;
+    }
+    current = current.parentElement;
+  }
+  return false;
 }
 
 function printPreview(viewport: HTMLElement): void {

--- a/packages/core/src/viewer.ts
+++ b/packages/core/src/viewer.ts
@@ -21,9 +21,10 @@ export function createViewer(options: PreviewOptions): FileViewer {
   const container = resolveContainer(options.container);
   applyBoxSize(container, options.width, options.height);
 
+  const customClassNames = parseClassNameTokens(options.className);
   container.classList.add("ofv-root");
-  if (options.className) {
-    container.classList.add(options.className);
+  if (customClassNames.length > 0) {
+    container.classList.add(...customClassNames);
   }
   const theme = applyTheme(container, options.theme || "light");
 
@@ -186,11 +187,15 @@ export function createViewer(options: PreviewOptions): FileViewer {
       theme.destroy();
       container.replaceChildren();
       container.classList.remove("ofv-root");
-      if (options.className) {
-        container.classList.remove(options.className);
+      if (customClassNames.length > 0) {
+        container.classList.remove(...customClassNames);
       }
     }
   };
+}
+
+function parseClassNameTokens(className: string | undefined): string[] {
+  return className?.trim().split(/\s+/).filter(Boolean) ?? [];
 }
 
 function destroyPreviewInstance(instance: PreviewInstance | undefined): void {


### PR DESCRIPTION
## Summary
- Move text preview controls, status text, large-file notices, and fallback copy into `PreviewMessages` with `zh-CN`/`en-US` defaults and custom message overrides.
- Localize legacy Office binary / unsupported guidance messages, including the strings rendered through `createTextNode`.
- Add a small `{placeholder}` formatter for dynamic message text such as line counts, sizes, and parser errors.

## Scope
This addresses the internationalization/message-configuration part of #46. The document page number display/adjustment request is intentionally left out because it is a separate UI behavior change.

## Tests
- `corepack pnpm vitest run packages/core/src/plugins/text.test.ts packages/core/src/plugins/office.test.ts --reporter verbose`
- `corepack pnpm vitest run packages/core/src/plugins/render-smoke.test.ts --reporter verbose`
- `corepack pnpm -r typecheck`
- `corepack pnpm test`
- `corepack pnpm -r --filter ./packages/** build`
- `corepack pnpm pack:check`
- `git diff --check`