### PR TITLE
feat(i18n): 让 pdf / image / text plugin 的文案支持 locale

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -19,8 +19,11 @@ export { model3dPlugin } from "./plugins/model3d";
 export { gisPlugin } from "./plugins/gis";
 export { assetPlugin } from "./plugins/asset";
 export { fallbackPlugin } from "./plugins/fallback";
+export { defaultMessages, formatMessage, resolveMessages } from "./messages";
 export type {
   FileViewer,
+  ImageMessages,
+  PdfMessages,
   PreviewCommand,
   PreviewContext,
   PreviewFallback,
@@ -30,6 +33,7 @@ export type {
   PreviewItem,
   PreviewLocale,
   PreviewMessages,
+  PreviewMessagesInput,
   PreviewOptions,
   PreviewPlugin,
   PreviewSize,
@@ -39,5 +43,6 @@ export type {
   PreviewToolbarBuiltInAction,
   PreviewToolbarCustomAction,
   PreviewToolbarOptions,
-  PreviewToolbarRenderContext
+  PreviewToolbarRenderContext,
+  TextMessages
 } from "./types";

--- a/packages/core/src/messages.test.ts
+++ b/packages/core/src/messages.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { defaultMessages, formatMessage, resolveMessages } from "./messages";
+
+describe("resolveMessages", () => {
+  it("defaults to en-US when no locale is provided", () => {
+    const messages = resolveMessages({});
+
+    expect(messages.loading).toBe("Loading preview...");
+    expect(messages.pdf.fallbackTitle).toBe("PDF preview failed");
+    expect(messages.image.fallbackTitle).toBe("Image preview failed");
+    expect(messages.text.fallbackTitle).toBe("Text preview failed");
+  });
+
+  it("returns the zh-CN plugin namespaces when the locale asks for them", () => {
+    const messages = resolveMessages({ locale: "zh-CN" });
+
+    expect(messages.pdf.fallbackTitle).toBe("PDF 预览失败");
+    expect(messages.image.fallbackTitle).toBe("图片预览失败");
+    expect(messages.text.fallbackTitle).toBe("文本预览失败");
+  });
+
+  it("merges plugin namespaces one level deep so a single key can be overridden", () => {
+    const messages = resolveMessages({ messages: { pdf: { download: "Save" } } });
+
+    expect(messages.pdf.download).toBe("Save");
+    // The rest of the pdf namespace must survive the override.
+    expect(messages.pdf.fallbackTitle).toBe(defaultMessages["en-US"].pdf.fallbackTitle);
+    expect(messages.pdf.encryptedTitle).toBe(defaultMessages["en-US"].pdf.encryptedTitle);
+    expect(messages.pdf.summaryPages).toBe(defaultMessages["en-US"].pdf.summaryPages);
+    // Sibling namespaces are untouched.
+    expect(messages.image).toEqual(defaultMessages["en-US"].image);
+    expect(messages.text).toEqual(defaultMessages["en-US"].text);
+  });
+
+  it("layers per-key overrides on top of the selected locale", () => {
+    const messages = resolveMessages({
+      locale: "zh-CN",
+      messages: { pdf: { download: "另存为" } }
+    });
+
+    expect(messages.pdf.download).toBe("另存为");
+    expect(messages.pdf.fallbackTitle).toBe("PDF 预览失败");
+  });
+
+  it("still merges the flat top-level keys", () => {
+    const messages = resolveMessages({ messages: { loading: "Working..." } });
+
+    expect(messages.loading).toBe("Working...");
+    expect(messages.downloadFile).toBe(defaultMessages["en-US"].downloadFile);
+    expect(messages.pdf).toEqual(defaultMessages["en-US"].pdf);
+  });
+
+  it("exposes matching keys for every locale", () => {
+    expect(Object.keys(defaultMessages["zh-CN"]).sort()).toEqual(Object.keys(defaultMessages["en-US"]).sort());
+    expect(Object.keys(defaultMessages["zh-CN"].pdf).sort()).toEqual(Object.keys(defaultMessages["en-US"].pdf).sort());
+    expect(Object.keys(defaultMessages["zh-CN"].image).sort()).toEqual(Object.keys(defaultMessages["en-US"].image).sort());
+    expect(Object.keys(defaultMessages["zh-CN"].text).sort()).toEqual(Object.keys(defaultMessages["en-US"].text).sort());
+  });
+});
+
+describe("formatMessage", () => {
+  it("fills placeholders by name", () => {
+    expect(formatMessage("Loading page {page}...", { page: 3 })).toBe("Loading page 3...");
+    expect(formatMessage("Page {page} / {total}", { page: 1, total: 2 })).toBe("Page 1 / 2");
+  });
+
+  it("leaves unknown placeholders untouched", () => {
+    expect(formatMessage("Loading page {page}...", {})).toBe("Loading page {page}...");
+  });
+
+  it("returns templates without placeholders unchanged", () => {
+    expect(formatMessage("Download PDF")).toBe("Download PDF");
+  });
+});

--- a/packages/core/src/messages.ts
+++ b/packages/core/src/messages.ts
@@ -1,4 +1,4 @@
-import type { PreviewLocale, PreviewMessages, PreviewOptions } from "./types";
+import type { PreviewLocale, PreviewMessages, PreviewMessagesInput, PreviewOptions } from "./types";
 
 export const defaultMessages: Record<PreviewLocale, PreviewMessages> = {
   "zh-CN": {
@@ -15,7 +15,79 @@ export const defaultMessages: Record<PreviewLocale, PreviewMessages> = {
     size: "大小",
     source: "来源",
     remoteUrl: "远程 URL",
-    localFile: "本地/内存文件"
+    localFile: "本地/内存文件",
+    pdf: {
+      pageLoading: "页面 {page} 加载中...",
+      pageEmpty:
+        "该页没有检测到可显示的 PDF 兼容内容。若这是 Illustrator/AI 文件，可能只包含私有编辑数据，建议导出为 PDF/SVG/PNG 后预览。",
+      pageError: "无法渲染该页面。该页可能包含浏览器 PDF 引擎暂不支持的图形、字体或压缩特性。",
+      summaryPages: "页数",
+      summaryPageSize: "页面尺寸",
+      summaryFit: "适配",
+      summaryFitActual: "原始大小",
+      summaryFitWidth: "适合宽度",
+      summaryZoom: "缩放",
+      fallbackTitle: "PDF 预览失败",
+      download: "下载 PDF",
+      errorCorrupted: "该 PDF 文件可能已损坏或格式无效。",
+      errorUnsupported: "当前浏览器无法加载该 PDF。",
+      encryptedTitle: "PDF 已加密，无法在线预览",
+      encryptedMessage: "请下载后使用密码打开，或上传解密后的 PDF 文件。",
+      encryptedAction: "下载 PDF"
+    },
+    image: {
+      fallbackTitle: "图片预览失败",
+      fallbackMessage: "当前浏览器无法直接显示该图片，文件可能已损坏或编码暂不受支持。",
+      download: "下载图片",
+      labelFormat: "格式",
+      labelDimensions: "尺寸",
+      labelBitDepth: "位深",
+      labelColor: "颜色",
+      labelFrames: "帧",
+      labelImages: "图像",
+      labelNote: "说明",
+      noteUnreadableHeader: "无法读取本地头信息",
+      noteUnrecognizedHeader: "暂未识别图片头结构",
+      noteJpegMissingSof: "未在头部扫描到 SOF 尺寸段",
+      noteWebpUnknownChunk: "未知 {chunk} 头",
+      noteBmpHeaderTooShort: "DIB header 太短",
+      noteTiffIfdOutOfRange: "IFD 偏移超出文件范围",
+      tiffEmpty: "无法读取 TIFF 文件内容。",
+      tiffNoImageDirectory: "TIFF 文件没有可解码的图像目录。",
+      tiffIncompletePixels: "TIFF 图像像素数据不完整。",
+      tiffCanvasUnsupported: "当前环境不支持 Canvas 2D，无法展示 TIFF。",
+      tiffPagesLabel: "{name}，共 {total} 页",
+      tiffPageCaption: "第 {page} / {total} 页 · {width} x {height}px",
+      tiffPageLabel: "{name} 第 {page} 页"
+    },
+    text: {
+      fallbackTitle: "文本预览失败",
+      fallbackMessage: "无法读取该文本内容，可能是远程文件不可访问或响应状态异常。",
+      openOriginal: "打开原文件",
+      plainText: "纯文本",
+      lines: "{count} 行",
+      actionWrap: "换行",
+      actionCopy: "复制",
+      actionDownload: "下载",
+      statusCopied: "已复制",
+      statusCopyFailed: "复制失败",
+      statusDownloadReady: "已开始下载",
+      truncatedNotice: "文件较大，当前展示前 {size}，复制和下载仍会使用完整内容。",
+      highlightSkippedNotice: "内容较大，已跳过语法高亮以保持滚动流畅。",
+      labelStructure: "结构",
+      labelEntries: "条目",
+      labelKeys: "键",
+      labelPreview: "预览",
+      labelTypes: "类型",
+      labelParsed: "可解析",
+      labelNotebook: "Notebook",
+      labelKernel: "Kernel",
+      labelNdjson: "NDJSON",
+      noKeys: "无键",
+      unknown: "未知",
+      notebookCells: "{count} 个单元格",
+      ndjsonLines: "{count} 行"
+    }
   },
   "en-US": {
     loading: "Loading preview...",
@@ -31,13 +103,105 @@ export const defaultMessages: Record<PreviewLocale, PreviewMessages> = {
     size: "Size",
     source: "Source",
     remoteUrl: "Remote URL",
-    localFile: "Local or in-memory file"
+    localFile: "Local or in-memory file",
+    pdf: {
+      pageLoading: "Loading page {page}...",
+      pageEmpty:
+        "No PDF-compatible content was found on this page. If this is an Illustrator/AI file it may only contain private editing data — export it to PDF/SVG/PNG before previewing.",
+      pageError:
+        "This page could not be rendered. It may use graphics, fonts, or compression features that the browser PDF engine does not support yet.",
+      summaryPages: "Pages",
+      summaryPageSize: "Page size",
+      summaryFit: "Fit",
+      summaryFitActual: "Actual size",
+      summaryFitWidth: "Fit width",
+      summaryZoom: "Zoom",
+      fallbackTitle: "PDF preview failed",
+      download: "Download PDF",
+      errorCorrupted: "This PDF file may be corrupted or invalid.",
+      errorUnsupported: "This PDF cannot be loaded in the current browser.",
+      encryptedTitle: "This PDF is encrypted and cannot be previewed",
+      encryptedMessage: "Download it and open it with the password, or upload a decrypted PDF file.",
+      encryptedAction: "Download PDF"
+    },
+    image: {
+      fallbackTitle: "Image preview failed",
+      fallbackMessage:
+        "The browser cannot display this image directly. The file may be corrupted or use an unsupported encoding.",
+      download: "Download image",
+      labelFormat: "Format",
+      labelDimensions: "Dimensions",
+      labelBitDepth: "Bit depth",
+      labelColor: "Color",
+      labelFrames: "Frames",
+      labelImages: "Images",
+      labelNote: "Note",
+      noteUnreadableHeader: "Local header information is unavailable",
+      noteUnrecognizedHeader: "Image header structure was not recognized",
+      noteJpegMissingSof: "No SOF size segment was found in the header",
+      noteWebpUnknownChunk: "Unknown {chunk} header",
+      noteBmpHeaderTooShort: "DIB header is too short",
+      noteTiffIfdOutOfRange: "IFD offset is out of file range",
+      tiffEmpty: "The TIFF file content could not be read.",
+      tiffNoImageDirectory: "The TIFF file has no decodable image directory.",
+      tiffIncompletePixels: "The TIFF image pixel data is incomplete.",
+      tiffCanvasUnsupported: "Canvas 2D is not supported in this environment, so the TIFF cannot be displayed.",
+      tiffPagesLabel: "{name}, {total} pages",
+      tiffPageCaption: "Page {page} / {total} · {width} x {height}px",
+      tiffPageLabel: "{name} page {page}"
+    },
+    text: {
+      fallbackTitle: "Text preview failed",
+      fallbackMessage:
+        "This text content could not be read. The remote file may be unreachable or the response status may be invalid.",
+      openOriginal: "Open original file",
+      plainText: "plain text",
+      lines: "{count} lines",
+      actionWrap: "Wrap",
+      actionCopy: "Copy",
+      actionDownload: "Download",
+      statusCopied: "Copied",
+      statusCopyFailed: "Copy failed",
+      statusDownloadReady: "Download ready",
+      truncatedNotice: "This file is large. Showing the first {size} — copy and download still use the full content.",
+      highlightSkippedNotice: "Content is large, so syntax highlighting was skipped to keep scrolling smooth.",
+      labelStructure: "Structure",
+      labelEntries: "Entries",
+      labelKeys: "Keys",
+      labelPreview: "Preview",
+      labelTypes: "Types",
+      labelParsed: "Parsed",
+      labelNotebook: "Notebook",
+      labelKernel: "Kernel",
+      labelNdjson: "NDJSON",
+      noKeys: "No keys",
+      unknown: "Unknown",
+      notebookCells: "{count} cells",
+      ndjsonLines: "{count} lines"
+    }
   }
 };
 
 export function resolveMessages(options: Pick<PreviewOptions, "locale" | "messages">): PreviewMessages {
+  const defaults = defaultMessages[options.locale || "en-US"];
+  const overrides: PreviewMessagesInput = options.messages || {};
   return {
-    ...defaultMessages[options.locale || "en-US"],
-    ...options.messages
+    ...defaults,
+    ...overrides,
+    pdf: { ...defaults.pdf, ...overrides.pdf },
+    image: { ...defaults.image, ...overrides.image },
+    text: { ...defaults.text, ...overrides.text }
   };
+}
+
+/**
+ * Fills `{placeholder}` slots in a message template.
+ *
+ * Messages stay plain serializable strings (rather than functions) so that they
+ * can be shipped in JSON locale files like any other i18n resource.
+ */
+export function formatMessage(template: string, values: Record<string, string | number> = {}): string {
+  return template.replace(/\{(\w+)\}/g, (match, key: string) =>
+    Object.prototype.hasOwnProperty.call(values, key) ? String(values[key]) : match
+  );
 }

--- a/packages/core/src/plugins/asset.ts
+++ b/packages/core/src/plugins/asset.ts
@@ -1,6 +1,6 @@
 import { createObjectUrl, revokeObjectUrl } from "../dom";
 import type { Psd } from "ag-psd";
-import type { PreviewCommand, PreviewInstance, PreviewPlugin, PreviewSize } from "../types";
+import type { PdfMessages, PreviewCommand, PreviewInstance, PreviewPlugin, PreviewSize } from "../types";
 import { renderPdfDocumentPreview } from "./pdf";
 import { appendMeta, createPanel, createSection, readArrayBuffer, resolveFormat } from "./utils";
 
@@ -79,7 +79,15 @@ export function assetPlugin(): PreviewPlugin {
       }
 
       if (extension === "ai" || extension === "eps" || extension === "ps") {
-        const postScriptPreview = await createPostScriptPreview(bytes, url, ctx.file.name, ctx.size, ctx.options.fit, ctx.toolbar);
+        const postScriptPreview = await createPostScriptPreview(
+          bytes,
+          url,
+          ctx.file.name,
+          ctx.size,
+          ctx.options.fit,
+          ctx.options.messages.pdf,
+          ctx.toolbar
+        );
         panel.append(postScriptPreview.element);
         if (postScriptPreview.primaryRendered) {
           hideSuccessfulAssetDiagnostics(panel);
@@ -2926,11 +2934,21 @@ async function createPostScriptPreview(
   fileName: string,
   size: { width: number; height: number },
   fit: string,
+  messages: PdfMessages,
   toolbar?: { setZoom(value: number | undefined): void }
 ): Promise<{ element: HTMLElement; instance?: PreviewInstance; primaryRendered?: boolean }> {
   const parsed = parsePostScript(bytes);
   if (parsed.valid && parsed.pdfCompatible) {
-    const embedded = await createPdfCompatibleAiPreview(bytes, url, fileName, size, fit, toolbar, parsed.pdfOffset || 0);
+    const embedded = await createPdfCompatibleAiPreview(
+      bytes,
+      url,
+      fileName,
+      size,
+      fit,
+      messages,
+      toolbar,
+      parsed.pdfOffset || 0
+    );
     return { element: embedded.element, instance: embedded.instance, primaryRendered: true };
   }
 
@@ -2969,6 +2987,7 @@ async function createPdfCompatibleAiPreview(
   fileName: string,
   size: { width: number; height: number },
   fit: string,
+  messages: PdfMessages,
   toolbar?: { setZoom(value: number | undefined): void },
   pdfOffset = 0,
   zoom = 1
@@ -2989,6 +3008,7 @@ async function createPdfCompatibleAiPreview(
     fit,
     zoom,
     toolbar,
+    messages,
     fallbackTitle: "AI PDF 兼容预览失败",
     revokeUrlOnDestroy: false
   });

--- a/packages/core/src/plugins/image.test.ts
+++ b/packages/core/src/plugins/image.test.ts
@@ -292,9 +292,9 @@ describe("imagePlugin", () => {
     await waitFor(() => Boolean(container.querySelector(".ofv-image-info")));
 
     expect(container.querySelector<HTMLElement>(".ofv-image-info")?.hidden).toBe(true);
-    expect(container.textContent).toContain("格式PNG");
-    expect(container.textContent).toContain("尺寸320 x 180px");
-    expect(container.textContent).toContain("位深8 bit");
+    expect(container.textContent).toContain("FormatPNG");
+    expect(container.textContent).toContain("Dimensions320 x 180px");
+    expect(container.textContent).toContain("Bit depth8 bit");
     expect(container.textContent).toContain("Truecolor + alpha");
 
     viewer.destroy();
@@ -318,8 +318,8 @@ describe("imagePlugin", () => {
 
     await waitFor(() => Boolean(svgContainer.querySelector(".ofv-image-info")));
     expect(svgContainer.querySelector<HTMLElement>(".ofv-image-info")?.hidden).toBe(true);
-    expect(svgContainer.textContent).toContain("格式SVG");
-    expect(svgContainer.textContent).toContain("尺寸640 x 360px");
+    expect(svgContainer.textContent).toContain("FormatSVG");
+    expect(svgContainer.textContent).toContain("Dimensions640 x 360px");
     expect(svgContainer.textContent).toContain("viewBox 0 0 640 360");
     svgViewer.destroy();
 
@@ -334,9 +334,9 @@ describe("imagePlugin", () => {
 
     await waitFor(() => Boolean(icoContainer.querySelector(".ofv-image-info")));
     expect(icoContainer.querySelector<HTMLElement>(".ofv-image-info")?.hidden).toBe(true);
-    expect(icoContainer.textContent).toContain("格式ICO");
-    expect(icoContainer.textContent).toContain("尺寸32 x 32px");
-    expect(icoContainer.textContent).toContain("图像2");
+    expect(icoContainer.textContent).toContain("FormatICO");
+    expect(icoContainer.textContent).toContain("Dimensions32 x 32px");
+    expect(icoContainer.textContent).toContain("Images2");
     icoViewer.destroy();
   });
 
@@ -359,8 +359,8 @@ describe("imagePlugin", () => {
     await waitFor(() => Boolean(container.querySelector(".ofv-image-info")));
 
     expect(container.querySelector<HTMLElement>(".ofv-image-info")?.hidden).toBe(true);
-    expect(container.textContent).toContain("格式APNG");
-    expect(container.textContent).toContain("帧2");
+    expect(container.textContent).toContain("FormatAPNG");
+    expect(container.textContent).toContain("Frames2");
 
     viewer.destroy();
   });
@@ -384,8 +384,8 @@ describe("imagePlugin", () => {
     await waitFor(() => Boolean(container.querySelector(".ofv-image-info")));
 
     expect(container.querySelector<HTMLElement>(".ofv-image-info")?.hidden).toBe(true);
-    expect(container.textContent).toContain("格式AVIF");
-    expect(container.textContent).toContain("尺寸1024 x 576px");
+    expect(container.textContent).toContain("FormatAVIF");
+    expect(container.textContent).toContain("Dimensions1024 x 576px");
     expect(container.textContent).toContain("brand avif");
     expect(container.textContent).toContain("mif1");
 
@@ -421,8 +421,8 @@ describe("imagePlugin", () => {
     expect(canvas?.width).toBe(2);
     expect(canvas?.height).toBe(1);
     expect(container.querySelector<HTMLElement>(".ofv-image-info")?.hidden).toBe(true);
-    expect(container.textContent).toContain("格式TIFF");
-    expect(container.textContent).toContain("尺寸2 x 1px");
+    expect(container.textContent).toContain("FormatTIFF");
+    expect(container.textContent).toContain("Dimensions2 x 1px");
     expect(utifMock.decodeImage).toHaveBeenCalledWith(expect.any(ArrayBuffer), ifd);
 
     viewer.destroy();
@@ -464,9 +464,9 @@ describe("imagePlugin", () => {
     expect(container.querySelector(".ofv-tiff-pages")).not.toBeNull();
     expect(container.querySelector(".ofv-image-stage-pages")).not.toBeNull();
     expect(canvases.map((canvas) => `${canvas.width}x${canvas.height}`)).toEqual(["2x1", "1x2"]);
-    expect(container.textContent).toContain("第 1 / 2 页");
-    expect(container.textContent).toContain("第 2 / 2 页");
-    expect(container.textContent).toContain("图像2");
+    expect(container.textContent).toContain("Page 1 / 2");
+    expect(container.textContent).toContain("Page 2 / 2");
+    expect(container.textContent).toContain("Images2");
     expect(utifMock.decodeImage).toHaveBeenCalledWith(expect.any(ArrayBuffer), first);
     expect(utifMock.decodeImage).toHaveBeenCalledWith(expect.any(ArrayBuffer), second);
 
@@ -501,7 +501,7 @@ describe("imagePlugin", () => {
 
     await waitFor(() => Boolean(container.querySelector(".ofv-fallback")));
 
-    expect(container.textContent).toContain("图片预览失败");
+    expect(container.textContent).toContain("Image preview failed");
     expect(container.querySelector<HTMLElement>(".ofv-image-info")?.hidden).toBe(false);
     expect(container.querySelector<HTMLAnchorElement>(".ofv-fallback a")?.href).toBe("blob:raw-tiff");
 
@@ -651,7 +651,7 @@ describe("imagePlugin", () => {
 
     await waitFor(() => Boolean(container.querySelector(".ofv-fallback")));
 
-    expect(container.textContent).toContain("图片预览失败");
+    expect(container.textContent).toContain("Image preview failed");
     expect(container.querySelector<HTMLAnchorElement>(".ofv-fallback a")?.href).toBe(objectUrl);
     expect(container.querySelector<HTMLButtonElement>('button[aria-label="Zoom in"]')?.disabled).toBe(true);
     expect(container.querySelector<HTMLButtonElement>('button[aria-label="Zoom out"]')?.disabled).toBe(true);
@@ -684,7 +684,7 @@ describe("imagePlugin", () => {
 
     await waitFor(() => Boolean(container.querySelector(".ofv-fallback")));
 
-    expect(container.textContent).toContain("图片预览失败");
+    expect(container.textContent).toContain("Image preview failed");
     expect(container.querySelector<HTMLAnchorElement>(".ofv-fallback a")?.href).toBe("blob:raw-heic");
 
     viewer.destroy();
@@ -879,3 +879,50 @@ function pointerEvent(type: string, init: PointerEventInit): Event {
   Object.defineProperty(event, "pointerId", { value: init.pointerId ?? 1 });
   return event;
 }
+
+describe("imagePlugin messages", () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+  });
+
+  it("renders the zh-CN info bar when the locale asks for it", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    const viewer = createViewer({
+      container,
+      file: minimalPng({ width: 320, height: 180 }),
+      fileName: "photo.png",
+      locale: "zh-CN",
+      plugins: [imagePlugin()]
+    });
+
+    await waitFor(() => Boolean(container.querySelector(".ofv-image-info")));
+
+    expect(container.textContent).toContain("格式PNG");
+    expect(container.textContent).toContain("尺寸320 x 180px");
+
+    viewer.destroy();
+  });
+
+  it("overrides a single image key without dropping the rest of the namespace", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    const viewer = createViewer({
+      container,
+      file: minimalPng({ width: 320, height: 180 }),
+      fileName: "photo.png",
+      messages: { image: { labelFormat: "Kind" } },
+      plugins: [imagePlugin()]
+    });
+
+    await waitFor(() => Boolean(container.querySelector(".ofv-image-info")));
+
+    expect(container.textContent).toContain("KindPNG");
+    expect(container.textContent).toContain("Dimensions320 x 180px");
+
+    viewer.destroy();
+  });
+});

--- a/packages/core/src/plugins/image.ts
+++ b/packages/core/src/plugins/image.ts
@@ -1,6 +1,7 @@
 /// <reference path="../shims-heic.d.ts" />
 import { createObjectUrl, revokeObjectUrl } from "../dom";
-import type { PreviewPlugin, PreviewSize } from "../types";
+import { formatMessage } from "../messages";
+import type { ImageMessages, PreviewPlugin, PreviewSize } from "../types";
 import { getInitialZoom } from "./utils";
 
 const imageExtensions = new Set([
@@ -38,6 +39,7 @@ export function imagePlugin(): PreviewPlugin {
       return file.mimeType.startsWith("image/") || imageExtensions.has(file.extension);
     },
     async render(ctx) {
+      const messages = ctx.options.messages.image;
       const ext = ctx.file.extension.toLowerCase();
       const isHeic = ext === "heic" || ext === "heif" || heicMimeTypes.has(ctx.file.mimeType.toLowerCase());
       const isTiff = ext === "tif" || ext === "tiff" || ctx.file.mimeType.toLowerCase() === "image/tiff";
@@ -52,7 +54,7 @@ export function imagePlugin(): PreviewPlugin {
         ctx.setLoading(true);
         try {
           const bytes = await sourceBytesPromise;
-          tiffSource = await createTiffPreview(bytes, ctx.file.name);
+          tiffSource = await createTiffPreview(bytes, ctx.file.name, messages);
         } catch (err: any) {
           console.error("TIFF image conversion failed:", err);
           url = createObjectUrl(ctx.file);
@@ -106,7 +108,7 @@ export function imagePlugin(): PreviewPlugin {
 
       const stage = document.createElement("div");
       stage.className = "ofv-image-stage";
-      const infoBar = createImageInfoBar(await sourceBytesPromise, ext, ctx.file.mimeType, ctx.file.name);
+      const infoBar = createImageInfoBar(await sourceBytesPromise, ext, ctx.file.mimeType, ctx.file.name, messages);
       infoBar.hidden = true;
       infoBar.setAttribute("aria-hidden", "true");
       infoBar.style.display = "none";
@@ -174,7 +176,7 @@ export function imagePlugin(): PreviewPlugin {
         infoBar.hidden = false;
         infoBar.removeAttribute("aria-hidden");
         infoBar.style.removeProperty("display");
-        stage.replaceChildren(createImageFallback(ctx.file.name, url));
+        stage.replaceChildren(createImageFallback(ctx.file.name, url, messages));
         ctx.toolbar?.refreshCommandSupport();
       };
 
@@ -388,19 +390,21 @@ export function imagePlugin(): PreviewPlugin {
   };
 }
 
-async function createTiffPreview(bytes: Uint8Array, fileName: string): Promise<HTMLElement> {
+async function createTiffPreview(bytes: Uint8Array, fileName: string, messages: ImageMessages): Promise<HTMLElement> {
   if (bytes.byteLength === 0) {
-    throw new Error("无法读取 TIFF 文件内容。");
+    throw new Error(messages.tiffEmpty);
   }
   const UTIF = await import("utif");
   const buffer = bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer;
   const ifds = UTIF.decode(buffer);
   const imageIfds = ifds.filter((item) => hasTiffDimensions(item));
   if (imageIfds.length === 0) {
-    throw new Error("TIFF 文件没有可解码的图像目录。");
+    throw new Error(messages.tiffNoImageDirectory);
   }
 
-  const pages = imageIfds.map((ifd, index) => createTiffPage(UTIF, buffer, ifd, index, imageIfds.length, fileName));
+  const pages = imageIfds.map((ifd, index) =>
+    createTiffPage(UTIF, buffer, ifd, index, imageIfds.length, fileName, messages)
+  );
   if (pages.length === 1) {
     return pages[0].canvas;
   }
@@ -408,13 +412,18 @@ async function createTiffPreview(bytes: Uint8Array, fileName: string): Promise<H
   const container = document.createElement("div");
   container.className = "ofv-tiff-pages";
   container.setAttribute("role", "group");
-  container.setAttribute("aria-label", `${fileName}，共 ${pages.length} 页`);
+  container.setAttribute("aria-label", formatMessage(messages.tiffPagesLabel, { name: fileName, total: pages.length }));
 
   for (const page of pages) {
     const figure = document.createElement("figure");
     figure.className = "ofv-tiff-page";
     const caption = document.createElement("figcaption");
-    caption.textContent = `第 ${page.index + 1} / ${pages.length} 页 · ${page.width} x ${page.height}px`;
+    caption.textContent = formatMessage(messages.tiffPageCaption, {
+      page: page.index + 1,
+      total: pages.length,
+      width: page.width,
+      height: page.height
+    });
     figure.append(page.canvas, caption);
     container.append(figure);
   }
@@ -428,13 +437,14 @@ function createTiffPage(
   ifd: Record<string, unknown>,
   index: number,
   total: number,
-  fileName: string
+  fileName: string,
+  messages: ImageMessages
 ): { canvas: HTMLCanvasElement; width: number; height: number; index: number } {
   UTIF.decodeImage(buffer, ifd);
   const rgba = UTIF.toRGBA8(ifd);
   const { width, height } = getTiffDimensions(ifd);
   if (!width || !height || rgba.length < width * height * 4) {
-    throw new Error("TIFF 图像像素数据不完整。");
+    throw new Error(messages.tiffIncompletePixels);
   }
 
   const canvas = document.createElement("canvas");
@@ -442,10 +452,13 @@ function createTiffPage(
   canvas.width = width;
   canvas.height = height;
   canvas.setAttribute("role", "img");
-  canvas.setAttribute("aria-label", total > 1 ? `${fileName} 第 ${index + 1} 页` : fileName);
+  canvas.setAttribute(
+    "aria-label",
+    total > 1 ? formatMessage(messages.tiffPageLabel, { name: fileName, page: index + 1 }) : fileName
+  );
   const context = canvas.getContext("2d");
   if (!context) {
-    throw new Error("当前环境不支持 Canvas 2D，无法展示 TIFF。");
+    throw new Error(messages.tiffCanvasUnsupported);
   }
   context.putImageData(new ImageData(new Uint8ClampedArray(rgba), width, height), 0, 0);
   return { canvas, width, height, index };
@@ -463,20 +476,20 @@ function getTiffDimensions(ifd: Record<string, unknown>): { width: number; heigh
   };
 }
 
-function createImageFallback(fileName: string, url: string): HTMLElement {
+function createImageFallback(fileName: string, url: string, messages: ImageMessages): HTMLElement {
   const fallback = document.createElement("div");
   fallback.className = "ofv-fallback";
 
   const title = document.createElement("strong");
-  title.textContent = "图片预览失败";
+  title.textContent = messages.fallbackTitle;
 
   const meta = document.createElement("span");
-  meta.textContent = "当前浏览器无法直接显示该图片，文件可能已损坏或编码暂不受支持。";
+  meta.textContent = messages.fallbackMessage;
 
   const download = document.createElement("a");
   download.href = url;
   download.download = fileName;
-  download.textContent = "下载图片";
+  download.textContent = messages.download;
 
   fallback.append(title, meta, download);
   return fallback;
@@ -512,28 +525,34 @@ async function readImageBytes(file: { blob?: Blob; url?: string; source?: unknow
   }
 }
 
-function createImageInfoBar(bytes: Uint8Array, extension: string, mimeType: string, fileName: string): HTMLElement {
-  const info = parseImageInfo(bytes, extension, mimeType, fileName);
+function createImageInfoBar(
+  bytes: Uint8Array,
+  extension: string,
+  mimeType: string,
+  fileName: string,
+  messages: ImageMessages
+): HTMLElement {
+  const info = parseImageInfo(bytes, extension, mimeType, fileName, messages);
   const bar = document.createElement("div");
   bar.className = "ofv-image-info";
-  appendImageInfo(bar, "格式", info.format);
+  appendImageInfo(bar, messages.labelFormat, info.format);
   if (info.width && info.height) {
-    appendImageInfo(bar, "尺寸", `${info.width} x ${info.height}px`);
+    appendImageInfo(bar, messages.labelDimensions, `${info.width} x ${info.height}px`);
   }
   if (info.bitDepth) {
-    appendImageInfo(bar, "位深", info.bitDepth);
+    appendImageInfo(bar, messages.labelBitDepth, info.bitDepth);
   }
   if (info.color) {
-    appendImageInfo(bar, "颜色", info.color);
+    appendImageInfo(bar, messages.labelColor, info.color);
   }
   if (info.frames !== undefined) {
-    appendImageInfo(bar, "帧", String(info.frames));
+    appendImageInfo(bar, messages.labelFrames, String(info.frames));
   }
   if (info.count !== undefined) {
-    appendImageInfo(bar, "图像", String(info.count));
+    appendImageInfo(bar, messages.labelImages, String(info.count));
   }
   if (info.note) {
-    appendImageInfo(bar, "说明", info.note);
+    appendImageInfo(bar, messages.labelNote, info.note);
   }
   return bar;
 }
@@ -549,22 +568,28 @@ function appendImageInfo(parent: HTMLElement, label: string, value: string): voi
   parent.append(row);
 }
 
-function parseImageInfo(bytes: Uint8Array, extension: string, mimeType: string, fileName: string): ImageInfo {
+function parseImageInfo(
+  bytes: Uint8Array,
+  extension: string,
+  mimeType: string,
+  fileName: string,
+  messages: ImageMessages
+): ImageInfo {
   const fallbackFormat = (extension || mimeType || fileName.split(".").pop() || "image").toUpperCase();
   if (bytes.length === 0) {
-    return { format: fallbackFormat, note: "无法读取本地头信息" };
+    return { format: fallbackFormat, note: messages.noteUnreadableHeader };
   }
   return (
     parsePngInfo(bytes) ||
-    parseJpegInfo(bytes) ||
+    parseJpegInfo(bytes, messages) ||
     parseGifInfo(bytes) ||
-    parseWebpInfo(bytes) ||
+    parseWebpInfo(bytes, messages) ||
     parseAvifInfo(bytes) ||
-    parseBmpInfo(bytes) ||
+    parseBmpInfo(bytes, messages) ||
     parseIcoInfo(bytes) ||
-    parseTiffInfo(bytes) ||
+    parseTiffInfo(bytes, messages) ||
     parseSvgInfo(bytes) ||
-    { format: fallbackFormat, note: "暂未识别图片头结构" }
+    { format: fallbackFormat, note: messages.noteUnrecognizedHeader }
   );
 }
 
@@ -584,7 +609,7 @@ function parsePngInfo(bytes: Uint8Array): ImageInfo | null {
   };
 }
 
-function parseJpegInfo(bytes: Uint8Array): ImageInfo | null {
+function parseJpegInfo(bytes: Uint8Array, messages: ImageMessages): ImageInfo | null {
   if (bytes.length < 4 || bytes[0] !== 0xff || bytes[1] !== 0xd8) {
     return null;
   }
@@ -620,7 +645,7 @@ function parseJpegInfo(bytes: Uint8Array): ImageInfo | null {
     }
     offset += length;
   }
-  return { format: "JPEG", note: "未在头部扫描到 SOF 尺寸段" };
+  return { format: "JPEG", note: messages.noteJpegMissingSof };
 }
 
 function parseGifInfo(bytes: Uint8Array): ImageInfo | null {
@@ -639,7 +664,7 @@ function parseGifInfo(bytes: Uint8Array): ImageInfo | null {
   };
 }
 
-function parseWebpInfo(bytes: Uint8Array): ImageInfo | null {
+function parseWebpInfo(bytes: Uint8Array, messages: ImageMessages): ImageInfo | null {
   if (bytes.length < 16 || asciiAt(bytes, 0, 4) !== "RIFF" || asciiAt(bytes, 8, 4) !== "WEBP") {
     return null;
   }
@@ -676,7 +701,7 @@ function parseWebpInfo(bytes: Uint8Array): ImageInfo | null {
       color: "Lossless"
     };
   }
-  return { format: "WebP", note: `未知 ${chunk || "chunk"} 头` };
+  return { format: "WebP", note: formatMessage(messages.noteWebpUnknownChunk, { chunk: chunk || "chunk" }) };
 }
 
 function parseAvifInfo(bytes: Uint8Array): ImageInfo | null {
@@ -761,13 +786,13 @@ function formatBmffBrands(value: string): string {
   return brands.slice(0, 6).join(", ");
 }
 
-function parseBmpInfo(bytes: Uint8Array): ImageInfo | null {
+function parseBmpInfo(bytes: Uint8Array, messages: ImageMessages): ImageInfo | null {
   if (bytes.length < 30 || asciiAt(bytes, 0, 2) !== "BM") {
     return null;
   }
   const dibSize = readUint32Le(bytes, 14);
   if (dibSize < 12) {
-    return { format: "BMP", note: "DIB header 太短" };
+    return { format: "BMP", note: messages.noteBmpHeaderTooShort };
   }
   if (dibSize === 12 && bytes.length >= 26) {
     return {
@@ -822,7 +847,7 @@ function parseSvgInfo(bytes: Uint8Array): ImageInfo | null {
   };
 }
 
-function parseTiffInfo(bytes: Uint8Array): ImageInfo | null {
+function parseTiffInfo(bytes: Uint8Array, messages: ImageMessages): ImageInfo | null {
   if (bytes.length < 8) {
     return null;
   }
@@ -837,7 +862,7 @@ function parseTiffInfo(bytes: Uint8Array): ImageInfo | null {
   }
   const ifdOffset = magic === 43 ? readTiffUint64AsNumber(bytes, 8, littleEndian) : readTiffUint32(bytes, 4, littleEndian);
   if (!Number.isFinite(ifdOffset) || ifdOffset + 2 > bytes.length) {
-    return { format: magic === 43 ? "BigTIFF" : "TIFF", note: "IFD 偏移超出文件范围" };
+    return { format: magic === 43 ? "BigTIFF" : "TIFF", note: messages.noteTiffIfdOutOfRange };
   }
   const count = magic === 43 ? readTiffUint64AsNumber(bytes, ifdOffset, littleEndian) : readTiffUint16(bytes, ifdOffset, littleEndian);
   const imageCount = countTiffIfds(bytes, ifdOffset, magic === 43, littleEndian);

--- a/packages/core/src/plugins/office.ts
+++ b/packages/core/src/plugins/office.ts
@@ -277,6 +277,7 @@ async function renderConvertedOfficePreview(
     fit: ctx.options.fit,
     zoom: ctx.options.zoom,
     toolbar: ctx.toolbar,
+    messages: ctx.options.messages.pdf,
     title: "Office 高保真转换预览",
     fallbackTitle: "Office 转换后的 PDF 无法预览",
     revokeUrlOnDestroy: converted.revokeUrlOnDestroy

--- a/packages/core/src/plugins/pdf.test.ts
+++ b/packages/core/src/plugins/pdf.test.ts
@@ -88,10 +88,10 @@ describe("pdfPlugin", () => {
 
     const summary = container.querySelector(".ofv-pdf-summary");
     expect((summary as HTMLElement | null)?.hidden).toBe(true);
-    expect(summary?.textContent).toContain("页数2");
-    expect(summary?.textContent).toContain("页面尺寸400 x 600 (2)");
-    expect(summary?.textContent).toContain("适配适合宽度");
-    expect(summary?.textContent).toContain("缩放100%");
+    expect(summary?.textContent).toContain("Pages2");
+    expect(summary?.textContent).toContain("Page size400 x 600 (2)");
+    expect(summary?.textContent).toContain("FitFit width");
+    expect(summary?.textContent).toContain("Zoom100%");
     const firstWrapper = container.querySelector<HTMLElement>(".ofv-pdf-page-wrapper");
     const zoomIn = container.querySelector<HTMLButtonElement>('button[aria-label="Zoom in"]');
     const zoomReset = container.querySelector<HTMLButtonElement>('button[aria-label="Reset zoom"]');
@@ -105,7 +105,7 @@ describe("pdfPlugin", () => {
 
     await waitFor(() => container.querySelector<HTMLElement>(".ofv-pdf-page-wrapper") !== firstWrapper);
 
-    expect(container.querySelector(".ofv-pdf-summary")?.textContent).toContain("缩放115%");
+    expect(container.querySelector(".ofv-pdf-summary")?.textContent).toContain("Zoom115%");
     expect(zoomReset?.textContent).toBe("115%");
     expect(container.querySelectorAll(".ofv-pdf-page-wrapper")).toHaveLength(2);
     const zoomedWrapper = container.querySelector<HTMLElement>(".ofv-pdf-page-wrapper");
@@ -262,7 +262,7 @@ describe("pdfPlugin", () => {
 
     await waitFor(() => Boolean(container.querySelector(".ofv-fallback")));
 
-    expect(container.textContent).toContain("PDF 预览失败");
+    expect(container.textContent).toContain("PDF preview failed");
     expect(container.querySelector<HTMLAnchorElement>(".ofv-fallback a")?.href).toBe("http://localhost:3000/missing.pdf");
 
     viewer.destroy();
@@ -392,7 +392,7 @@ describe("pdfPlugin", () => {
 
     await waitFor(() => Boolean(container.querySelector(".ofv-pdf-empty")));
 
-    expect(container.querySelector(".ofv-pdf-empty")?.textContent).toContain("没有检测到可显示的 PDF 兼容内容");
+    expect(container.querySelector(".ofv-pdf-empty")?.textContent).toContain("No PDF-compatible content was found on this page");
     expect(container.querySelector(".ofv-pdf-empty")?.textContent).toContain("Illustrator/AI");
 
     viewer.destroy();
@@ -428,8 +428,8 @@ describe("pdfPlugin", () => {
     await waitFor(() => Boolean(container.querySelector(".ofv-fallback")));
 
     expect(container.querySelector(".ofv-encrypted")).not.toBeNull();
-    expect(container.textContent).toContain("PDF 已加密，无法在线预览");
-    expect(container.textContent).toContain("上传解密后的 PDF 文件");
+    expect(container.textContent).toContain("This PDF is encrypted and cannot be previewed");
+    expect(container.textContent).toContain("upload a decrypted PDF file");
     expect(container.querySelector<HTMLAnchorElement>(".ofv-fallback a")?.href).toBe(objectUrl);
     expect(onError).not.toHaveBeenCalled();
 
@@ -467,8 +467,8 @@ describe("pdfPlugin", () => {
     await waitFor(() => Boolean(container.querySelector(".ofv-pdf-error")));
 
     expect(container.querySelectorAll(".ofv-pdf-page-wrapper")).toHaveLength(2);
-    expect(container.querySelector(".ofv-pdf-error")?.textContent).toContain("无法渲染该页面");
-    expect(container.querySelector(".ofv-pdf-error")?.textContent).toContain("图形、字体或压缩特性");
+    expect(container.querySelector(".ofv-pdf-error")?.textContent).toContain("This page could not be rendered");
+    expect(container.querySelector(".ofv-pdf-error")?.textContent).toContain("graphics, fonts, or compression features");
     expect(container.querySelector(".ofv-pdf-error")?.textContent).not.toContain("Illustrator/PostScript");
 
     viewer.destroy();
@@ -651,3 +651,62 @@ async function waitFor(predicate: () => boolean, timeout = 1000): Promise<void> 
     await new Promise((resolve) => setTimeout(resolve, 0));
   }
 }
+
+describe("pdfPlugin messages", () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, "getContext").mockReturnValue({} as CanvasRenderingContext2D);
+  });
+
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+  });
+
+  it("renders the zh-CN copy when the locale asks for it", async () => {
+    const container = createSizedContainer();
+    const viewer = createViewer({
+      container,
+      file: new Blob(["pdf"], { type: "application/pdf" }),
+      fileName: "sample.pdf",
+      locale: "zh-CN",
+      toolbar: true,
+      plugins: [pdfPlugin({ pdfjs: createPdfJsMock() })]
+    });
+
+    await waitFor(() => container.querySelectorAll(".ofv-pdf-page-wrapper").length === 2);
+
+    const summary = container.querySelector(".ofv-pdf-summary");
+    expect(summary?.textContent).toContain("页数2");
+    expect(summary?.textContent).toContain("适配适合宽度");
+
+    viewer.destroy();
+  });
+
+  it("overrides a single pdf key without dropping the rest of the namespace", async () => {
+    const container = createSizedContainer();
+    const fetchMock = vi.fn().mockResolvedValue(
+      Object.assign(new Response(null, { status: 404, statusText: "Not Found" }), {
+        arrayBuffer: vi.fn()
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const viewer = createViewer({
+      container,
+      file: "/missing.pdf",
+      fileName: "missing.pdf",
+      mimeType: "application/pdf",
+      messages: { pdf: { download: "Save a copy" } },
+      plugins: [pdfPlugin({ pdfjs: createPdfJsMock(), useFetchData: true })]
+    });
+
+    await waitFor(() => Boolean(container.querySelector(".ofv-fallback")));
+
+    // The overridden key wins...
+    expect(container.querySelector(".ofv-fallback a")?.textContent).toBe("Save a copy");
+    // ...and the sibling keys still come from the en-US defaults.
+    expect(container.textContent).toContain("PDF preview failed");
+
+    viewer.destroy();
+  });
+});

--- a/packages/core/src/plugins/pdf.ts
+++ b/packages/core/src/plugins/pdf.ts
@@ -1,5 +1,6 @@
 import { createObjectUrl, revokeObjectUrl } from "../dom";
-import type { PreviewPlugin, PreviewSize } from "../types";
+import { defaultMessages, formatMessage } from "../messages";
+import type { PdfMessages, PreviewPlugin, PreviewSize } from "../types";
 import { createEncryptedFallback, isEncryptedError } from "./encrypted";
 import { getInitialZoom } from "./utils";
 
@@ -48,7 +49,14 @@ export interface PdfDocumentPreviewOptions {
   disableRange?: boolean;
   rangeChunkSize?: number;
   useFetchData?: boolean;
+  /**
+   * Copy used by the PDF surface. Defaults to the `en-US` messages, matching
+   * `resolveMessages()`. Plugins that own a `PreviewContext` should forward
+   * `ctx.options.messages.pdf`.
+   */
+  messages?: PdfMessages;
   title?: string;
+  /** Overrides `messages.fallbackTitle`, so embedding plugins can name their own surface. */
   fallbackTitle?: string;
   encryptedTitle?: string;
   encryptedMessage?: string;
@@ -89,9 +97,7 @@ export function pdfPlugin(options: PdfJsModule | PdfPluginOptions = {}): Preview
         fit: ctx.options.fit,
         zoom: ctx.options.zoom,
         toolbar: ctx.toolbar,
-        encryptedTitle: "PDF 已加密，无法在线预览",
-        encryptedMessage: "请下载后使用密码打开，或上传解密后的 PDF 文件。",
-        encryptedAction: "下载 PDF",
+        messages: ctx.options.messages.pdf,
         revokeUrlOnDestroy: true
       });
     }
@@ -106,6 +112,8 @@ export async function renderPdfDocumentPreview(options: PdfDocumentPreviewOption
 }> {
   const pdf = options.pdfjs || (await import("pdfjs-dist"));
   configurePdfWorker(pdf, options.workerSrc);
+
+  const messages = options.messages || defaultMessages["en-US"].pdf;
 
   const viewer = document.createElement("div");
   viewer.className = "ofv-pdf-viewer";
@@ -138,11 +146,17 @@ export async function renderPdfDocumentPreview(options: PdfDocumentPreviewOption
     };
     const fallback = isEncryptedError(error)
       ? createEncryptedFallback(fileLike, options.fileUrl, {
-          title: options.encryptedTitle || "PDF 已加密，无法在线预览",
-          message: options.encryptedMessage || "请下载后使用密码打开，或上传解密后的 PDF 文件。",
-          action: options.encryptedAction || "下载 PDF"
+          title: options.encryptedTitle || messages.encryptedTitle,
+          message: options.encryptedMessage || messages.encryptedMessage,
+          action: options.encryptedAction || messages.encryptedAction
         })
-      : createPdfFallback(options.fileName, options.fileUrl, normalizePdfError(error), options.fallbackTitle);
+      : createPdfFallback(
+          options.fileName,
+          options.fileUrl,
+          normalizePdfError(error, messages),
+          messages,
+          options.fallbackTitle
+        );
     options.viewport.append(fallback);
   };
 
@@ -217,7 +231,7 @@ export async function renderPdfDocumentPreview(options: PdfDocumentPreviewOption
   let rotation = 0;
 
   const updateSummary = () => {
-    renderPdfSummary(summary, pdfDocument.numPages, pagesMeta, options.fit, zoomFactor);
+    renderPdfSummary(summary, pdfDocument.numPages, pagesMeta, options.fit, zoomFactor, messages);
     options.toolbar?.setZoom(zoomFactor);
   };
 
@@ -237,7 +251,9 @@ export async function renderPdfDocumentPreview(options: PdfDocumentPreviewOption
     state.canvas = null;
     state.rendered = false;
     state.wrapper.replaceChildren();
-    state.wrapper.append(createPageStatus("ofv-pdf-skeleton", `页面 ${pageIdx + 1} 加载中...`));
+    state.wrapper.append(
+      createPageStatus("ofv-pdf-skeleton", formatMessage(messages.pageLoading, { page: pageIdx + 1 }))
+    );
   };
 
   const renderPage = async (pageIdx: number, size: PreviewSize) => {
@@ -319,19 +335,12 @@ export async function renderPdfDocumentPreview(options: PdfDocumentPreviewOption
         }
       }
       if (textLayer.childElementCount === 0 && isCanvasVisuallyBlank(canvas, context)) {
-        state.wrapper.appendChild(
-          createPageStatus(
-            "ofv-pdf-empty",
-            "该页没有检测到可显示的 PDF 兼容内容。若这是 Illustrator/AI 文件，可能只包含私有编辑数据，建议导出为 PDF/SVG/PNG 后预览。"
-          )
-        );
+        state.wrapper.appendChild(createPageStatus("ofv-pdf-empty", messages.pageEmpty));
       }
     } catch (err) {
       console.error(`Failed to render PDF page ${pageIdx + 1}:`, err);
       state.rendered = false;
-      state.wrapper.replaceChildren(
-        createPageStatus("ofv-pdf-error", "无法渲染该页面。该页可能包含浏览器 PDF 引擎暂不支持的图形、字体或压缩特性。")
-      );
+      state.wrapper.replaceChildren(createPageStatus("ofv-pdf-error", messages.pageError));
     }
   };
 
@@ -382,7 +391,7 @@ export async function renderPdfDocumentPreview(options: PdfDocumentPreviewOption
       wrapper.setAttribute("data-page-index", String(i));
       wrapper.style.width = `${w}px`;
       wrapper.style.height = `${h}px`;
-      wrapper.append(createPageStatus("ofv-pdf-skeleton", `页面 ${i + 1} 加载中...`));
+      wrapper.append(createPageStatus("ofv-pdf-skeleton", formatMessage(messages.pageLoading, { page: i + 1 })));
 
       scroller.appendChild(wrapper);
 
@@ -513,16 +522,17 @@ function renderPdfSummary(
   pages: number,
   pagesMeta: Array<{ width: number; height: number }>,
   fit: string,
-  zoomFactor: number
+  zoomFactor: number,
+  messages: PdfMessages
 ): void {
   summary.replaceChildren();
-  appendPdfSummary(summary, "页数", String(pages));
+  appendPdfSummary(summary, messages.summaryPages, String(pages));
   const pageSizes = formatPdfPageSizes(pagesMeta);
   if (pageSizes) {
-    appendPdfSummary(summary, "页面尺寸", pageSizes);
+    appendPdfSummary(summary, messages.summaryPageSize, pageSizes);
   }
-  appendPdfSummary(summary, "适配", fit === "actual" ? "原始大小" : "适合宽度");
-  appendPdfSummary(summary, "缩放", `${Math.round(zoomFactor * 100)}%`);
+  appendPdfSummary(summary, messages.summaryFit, fit === "actual" ? messages.summaryFitActual : messages.summaryFitWidth);
+  appendPdfSummary(summary, messages.summaryZoom, `${Math.round(zoomFactor * 100)}%`);
 }
 
 function appendPdfSummary(parent: HTMLElement, label: string, value: string): void {
@@ -629,7 +639,13 @@ function createPageStatus(className: string, text: string): HTMLDivElement {
   return status;
 }
 
-function createPdfFallback(fileName: string, url: string, message: string, titleText = "PDF 预览失败"): HTMLElement {
+function createPdfFallback(
+  fileName: string,
+  url: string,
+  message: string,
+  messages: PdfMessages,
+  titleText = messages.fallbackTitle
+): HTMLElement {
   const fallback = document.createElement("div");
   fallback.className = "ofv-fallback";
 
@@ -642,20 +658,20 @@ function createPdfFallback(fileName: string, url: string, message: string, title
   const download = document.createElement("a");
   download.href = url;
   download.download = fileName;
-  download.textContent = "下载 PDF";
+  download.textContent = messages.download;
 
   fallback.append(title, meta, download);
   return fallback;
 }
 
-function normalizePdfError(error: unknown): string {
+function normalizePdfError(error: unknown, messages: PdfMessages): string {
   const message = error instanceof Error ? error.message : String(error || "");
   const name = typeof error === "object" && error !== null && "name" in error ? String((error as { name?: unknown }).name) : "";
   const lower = `${name} ${message}`.toLowerCase();
   if (lower.includes("invalid") || lower.includes("missing") || lower.includes("corrupt")) {
-    return "该 PDF 文件可能已损坏或格式无效。";
+    return messages.errorCorrupted;
   }
-  return "当前浏览器无法加载该 PDF。";
+  return messages.errorUnsupported;
 }
 
 function configurePdfWorker(pdf: PdfJsModule, workerSrc?: string): void {

--- a/packages/core/src/plugins/render-smoke.test.ts
+++ b/packages/core/src/plugins/render-smoke.test.ts
@@ -1370,7 +1370,7 @@ function smokeCases(): SmokeCase[] {
       fileName: "locked.pdf",
       plugins: [pdfPlugin({ pdfjs: failingPdfJs() as any })],
       selector: ".ofv-fallback",
-      text: "PDF 预览失败"
+      text: "PDF preview failed"
     },
     {
       name: "EPUB",

--- a/packages/core/src/plugins/text.test.ts
+++ b/packages/core/src/plugins/text.test.ts
@@ -138,7 +138,7 @@ describe("textPlugin", () => {
 
     await waitFor(() => Boolean(container.querySelector(".ofv-fallback")));
 
-    expect(container.textContent).toContain("文本预览失败");
+    expect(container.textContent).toContain("Text preview failed");
     expect(container.querySelector<HTMLAnchorElement>(".ofv-fallback a")?.href).toBe("https://example.com/missing.txt");
     expect(onError).not.toHaveBeenCalled();
   });
@@ -269,10 +269,10 @@ describe("textPlugin", () => {
 
     const summary = container.querySelector<HTMLElement>(".ofv-text-structure");
     expect(summary?.hidden).toBe(true);
-    expect(summary?.textContent).toContain("结构Object");
-    expect(summary?.textContent).toContain("键3");
-    expect(visibleText(container)).not.toContain("结构Object");
-    expect(visibleText(container)).not.toContain("键3");
+    expect(summary?.textContent).toContain("StructureObject");
+    expect(summary?.textContent).toContain("Keys3");
+    expect(visibleText(container)).not.toContain("StructureObject");
+    expect(visibleText(container)).not.toContain("Keys3");
   });
 
   it("renders notebook cell summaries", async () => {
@@ -322,10 +322,10 @@ describe("textPlugin", () => {
     const summary = container.querySelector<HTMLElement>(".ofv-text-structure");
     expect(summary?.hidden).toBe(true);
     expect(summary?.textContent).toContain("NDJSON4 lines");
-    expect(summary?.textContent).toContain("可解析3");
+    expect(summary?.textContent).toContain("Parsed3");
     expect(summary?.textContent).toContain("object 2, array 1");
     expect(visibleText(container)).not.toContain("NDJSON4 lines");
-    expect(visibleText(container)).not.toContain("可解析3");
+    expect(visibleText(container)).not.toContain("Parsed3");
   });
 
   it.each([
@@ -582,7 +582,7 @@ describe("textPlugin", () => {
 
     await waitFor(() => Boolean(container.querySelector(".ofv-code-container.is-truncated")));
 
-    expect(container.querySelector(".ofv-code-notice")?.textContent).toContain("文件较大");
+    expect(container.querySelector(".ofv-code-notice")?.textContent).toContain("This file is large");
     expect(container.querySelector(".ofv-code-container code")?.textContent).not.toContain("TAIL");
 
     const copy = Array.from(container.querySelectorAll<HTMLButtonElement>(".ofv-code-action")).find(
@@ -637,3 +637,52 @@ function visibleText(root: HTMLElement): string {
   walk(root, false);
   return parts.join(" ").replace(/\s+/g, " ").trim();
 }
+
+describe("textPlugin messages", () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+    vi.restoreAllMocks();
+  });
+
+  it("renders the zh-CN code header and summary when the locale asks for it", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    const viewer = createViewer({
+      container,
+      file: new Blob(['{"a":1,"b":2,"c":3}'], { type: "application/json" }),
+      fileName: "data.json",
+      locale: "zh-CN",
+      plugins: [textPlugin()]
+    });
+
+    await waitFor(() => container.querySelector(".ofv-code-container"));
+
+    expect(container.querySelector(".ofv-code-actions")?.textContent).toContain("复制");
+    expect(container.querySelector(".ofv-text-structure")?.textContent).toContain("结构Object");
+
+    viewer.destroy();
+  });
+
+  it("overrides a single text key without dropping the rest of the namespace", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    const viewer = createViewer({
+      container,
+      file: new Blob(['{"a":1,"b":2,"c":3}'], { type: "application/json" }),
+      fileName: "data.json",
+      messages: { text: { actionCopy: "Duplicate" } },
+      plugins: [textPlugin()]
+    });
+
+    await waitFor(() => container.querySelector(".ofv-code-container"));
+
+    const actions = container.querySelector(".ofv-code-actions")?.textContent;
+    expect(actions).toContain("Duplicate");
+    expect(actions).toContain("Wrap");
+    expect(actions).toContain("Download");
+
+    viewer.destroy();
+  });
+});

--- a/packages/core/src/plugins/text.ts
+++ b/packages/core/src/plugins/text.ts
@@ -1,6 +1,7 @@
 /// <reference path="../shims-text.d.ts" />
 import { isTextLike } from "../detect";
-import type { PreviewCommand, PreviewContext, PreviewPlugin } from "../types";
+import { formatMessage } from "../messages";
+import type { PreviewCommand, PreviewContext, PreviewPlugin, TextMessages } from "../types";
 import { decodeTextBuffer, getInitialZoom } from "./utils";
 
 const langMap: Record<string, string> = {
@@ -168,13 +169,14 @@ export function textPlugin(): PreviewPlugin {
       return isTextLike(file);
     },
     async render(ctx) {
+      const messages = ctx.options.messages.text;
       const ext = ctx.file.extension.toLowerCase();
       const lang = getTextLanguage(ctx.file.name, ext, ctx.file.mimeType);
       const defaultWrapped = lang === "none";
       const isMarkdown = lang === "markdown";
       const text = await readText(ctx.file.source).catch((error: unknown) => undefined);
       if (text === undefined) {
-        const fallback = createTextFallback(ctx.file.name, ctx.file.url);
+        const fallback = createTextFallback(ctx.file.name, messages, ctx.file.url);
         ctx.viewport.classList.add("ofv-center");
         ctx.viewport.append(fallback);
         return {
@@ -364,8 +366,8 @@ export function textPlugin(): PreviewPlugin {
       fileName.textContent = ctx.file.name;
       const meta = document.createElement("span");
       meta.textContent = [
-        lang === "none" ? "plain text" : lang,
-        `${totalLines.toLocaleString()} lines`,
+        lang === "none" ? messages.plainText : lang,
+        formatMessage(messages.lines, { count: totalLines.toLocaleString() }),
         formatBytes(ctx.file.size ?? (ctx.file.source instanceof Blob ? ctx.file.source.size : text.length))
       ].join(" · ");
       title.append(fileName, meta);
@@ -380,7 +382,7 @@ export function textPlugin(): PreviewPlugin {
       const wrapButton = document.createElement("button");
       wrapButton.type = "button";
       wrapButton.className = "ofv-code-action";
-      wrapButton.textContent = "Wrap";
+      wrapButton.textContent = messages.actionWrap;
       wrapButton.setAttribute("aria-pressed", String(defaultWrapped));
       wrapButton.addEventListener("click", () => {
         const wrapped = wrapper.classList.toggle("is-wrapped");
@@ -390,14 +392,14 @@ export function textPlugin(): PreviewPlugin {
       const copyButton = document.createElement("button");
       copyButton.type = "button";
       copyButton.className = "ofv-code-action";
-      copyButton.textContent = "Copy";
+      copyButton.textContent = messages.actionCopy;
       copyButton.addEventListener("click", async () => {
         copyButton.disabled = true;
         try {
           await copyToClipboard(text);
-          status.textContent = "Copied";
+          status.textContent = messages.statusCopied;
         } catch {
-          status.textContent = "Copy failed";
+          status.textContent = messages.statusCopyFailed;
         } finally {
           copyButton.disabled = false;
         }
@@ -406,15 +408,15 @@ export function textPlugin(): PreviewPlugin {
       const downloadButton = document.createElement("button");
       downloadButton.type = "button";
       downloadButton.className = "ofv-code-action";
-      downloadButton.textContent = "Download";
+      downloadButton.textContent = messages.actionDownload;
       downloadButton.addEventListener("click", () => {
         downloadText(ctx.file.name, text);
-        status.textContent = "Download ready";
+        status.textContent = messages.statusDownloadReady;
       });
 
       actions.append(wrapButton, copyButton, downloadButton, status);
       header.append(title, actions);
-      const structureSummary = createTextStructureSummary(text, ext, lang, ctx.file.mimeType);
+      const structureSummary = createTextStructureSummary(text, ext, lang, ctx.file.mimeType, messages);
 
       const body = document.createElement("div");
       body.className = "ofv-code-body";
@@ -440,13 +442,13 @@ export function textPlugin(): PreviewPlugin {
       if (truncated) {
         const notice = document.createElement("div");
         notice.className = "ofv-code-notice";
-        notice.textContent = `文件较大，当前展示前 ${formatBytes(codeText.length)}，复制和下载仍会使用完整内容。`;
+        notice.textContent = formatMessage(messages.truncatedNotice, { size: formatBytes(codeText.length) });
         wrapper.append(notice);
       }
       if (!shouldHighlight) {
         const notice = document.createElement("div");
         notice.className = "ofv-code-notice";
-        notice.textContent = "内容较大，已跳过语法高亮以保持滚动流畅。";
+        notice.textContent = messages.highlightSkippedNotice;
         wrapper.append(notice);
       }
       wrapper.appendChild(body);
@@ -529,22 +531,22 @@ function normalizeFileName(name: string): string {
   return baseName.toLowerCase();
 }
 
-function createTextFallback(fileName: string, url?: string): HTMLElement {
+function createTextFallback(fileName: string, messages: TextMessages, url?: string): HTMLElement {
   const fallback = document.createElement("div");
   fallback.className = "ofv-fallback";
 
   const title = document.createElement("strong");
-  title.textContent = "文本预览失败";
+  title.textContent = messages.fallbackTitle;
 
   const meta = document.createElement("span");
-  meta.textContent = "无法读取该文本内容，可能是远程文件不可访问或响应状态异常。";
+  meta.textContent = messages.fallbackMessage;
 
   fallback.append(title, meta);
   if (url) {
     const download = document.createElement("a");
     download.href = url;
     download.download = fileName;
-    download.textContent = "打开原文件";
+    download.textContent = messages.openOriginal;
     fallback.append(download);
   }
   return fallback;
@@ -584,11 +586,17 @@ function countLines(text: string): number {
   return text.split(/\r\n|\r|\n/).length;
 }
 
-function createTextStructureSummary(text: string, extension: string, language: string, mimeType: string): HTMLElement | null {
+function createTextStructureSummary(
+  text: string,
+  extension: string,
+  language: string,
+  mimeType: string,
+  messages: TextMessages
+): HTMLElement | null {
   if (text.length > MAX_RENDER_CHARS) {
     return null;
   }
-  const items = summarizeTextStructure(text, extension, language, mimeType);
+  const items = summarizeTextStructure(text, extension, language, mimeType, messages);
   if (items.length === 0) {
     return null;
   }
@@ -613,51 +621,52 @@ function summarizeTextStructure(
   text: string,
   extension: string,
   language: string,
-  mimeType: string
+  mimeType: string,
+  messages: TextMessages
 ): Array<{ label: string; value: string }> {
   if (extension === "ipynb" || mimeType === "application/x-ipynb+json") {
-    return summarizeNotebook(text);
+    return summarizeNotebook(text, messages);
   }
   if (extension === "ndjson" || extension === "jsonl" || mimeType === "application/x-ndjson") {
-    return summarizeNdjson(text);
+    return summarizeNdjson(text, messages);
   }
   if (language === "json" || language === "json5") {
-    return summarizeJson(text);
+    return summarizeJson(text, messages);
   }
   return [];
 }
 
-function summarizeJson(text: string): Array<{ label: string; value: string }> {
+function summarizeJson(text: string, messages: TextMessages): Array<{ label: string; value: string }> {
   try {
     const data = JSON.parse(text) as unknown;
     if (Array.isArray(data)) {
       return [
-        { label: "结构", value: "Array" },
-        { label: "条目", value: String(data.length) }
+        { label: messages.labelStructure, value: "Array" },
+        { label: messages.labelEntries, value: String(data.length) }
       ];
     }
     if (data && typeof data === "object") {
       const keys = Object.keys(data as Record<string, unknown>);
       return [
-        { label: "结构", value: "Object" },
-        { label: "键", value: String(keys.length) },
-        { label: "预览", value: keys.slice(0, 8).join(", ") || "无键" }
+        { label: messages.labelStructure, value: "Object" },
+        { label: messages.labelKeys, value: String(keys.length) },
+        { label: messages.labelPreview, value: keys.slice(0, 8).join(", ") || messages.noKeys }
       ];
     }
-    return [{ label: "结构", value: typeof data }];
+    return [{ label: messages.labelStructure, value: typeof data }];
   } catch {
     return [];
   }
 }
 
-function summarizeNotebook(text: string): Array<{ label: string; value: string }> {
+function summarizeNotebook(text: string, messages: TextMessages): Array<{ label: string; value: string }> {
   try {
     const notebook = JSON.parse(text) as {
       cells?: Array<{ cell_type?: string; source?: string | string[] }>;
       metadata?: { kernelspec?: { display_name?: string; name?: string }; language_info?: { name?: string } };
     };
     if (!Array.isArray(notebook.cells)) {
-      return summarizeJson(text);
+      return summarizeJson(text, messages);
     }
     const counts = new Map<string, number>();
     for (const cell of notebook.cells) {
@@ -666,16 +675,19 @@ function summarizeNotebook(text: string): Array<{ label: string; value: string }
     }
     const kernel = notebook.metadata?.kernelspec?.display_name || notebook.metadata?.kernelspec?.name || notebook.metadata?.language_info?.name;
     return [
-      { label: "Notebook", value: `${notebook.cells.length} cells` },
-      { label: "类型", value: [...counts.entries()].map(([type, count]) => `${type} ${count}`).join(", ") || "未知" },
-      ...(kernel ? [{ label: "Kernel", value: kernel }] : [])
+      { label: messages.labelNotebook, value: formatMessage(messages.notebookCells, { count: notebook.cells.length }) },
+      {
+        label: messages.labelTypes,
+        value: [...counts.entries()].map(([type, count]) => `${type} ${count}`).join(", ") || messages.unknown
+      },
+      ...(kernel ? [{ label: messages.labelKernel, value: kernel }] : [])
     ];
   } catch {
     return [];
   }
 }
 
-function summarizeNdjson(text: string): Array<{ label: string; value: string }> {
+function summarizeNdjson(text: string, messages: TextMessages): Array<{ label: string; value: string }> {
   const lines = text.split(/\r\n|\r|\n/).filter((line) => line.trim());
   let parsed = 0;
   let objects = 0;
@@ -694,9 +706,9 @@ function summarizeNdjson(text: string): Array<{ label: string; value: string }> 
     }
   }
   return [
-    { label: "NDJSON", value: `${lines.length} lines` },
-    { label: "可解析", value: String(parsed) },
-    { label: "类型", value: `object ${objects}, array ${arrays}` }
+    { label: messages.labelNdjson, value: formatMessage(messages.ndjsonLines, { count: lines.length }) },
+    { label: messages.labelParsed, value: String(parsed) },
+    { label: messages.labelTypes, value: `object ${objects}, array ${arrays}` }
   ];
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -109,7 +109,7 @@ export interface PreviewOptions {
   plugins?: PreviewPlugin[];
   fallback?: PreviewFallback;
   locale?: PreviewLocale;
-  messages?: Partial<PreviewMessages>;
+  messages?: PreviewMessagesInput;
   renderFallback?: (ctx: PreviewContext) => Promise<PreviewInstance> | PreviewInstance;
   toolbar?: boolean | PreviewToolbarOptions;
   theme?: PreviewTheme;
@@ -134,7 +134,114 @@ export interface PreviewMessages {
   source: string;
   remoteUrl: string;
   localFile: string;
+  pdf: PdfMessages;
+  image: ImageMessages;
+  text: TextMessages;
 }
+
+/**
+ * Messages consumed by the `pdf` plugin.
+ *
+ * Values wrapped in braces are placeholders filled in by `formatMessage`,
+ * e.g. `pageLoading: "Loading page {page}..."`.
+ */
+export interface PdfMessages {
+  /** Placeholders: `{page}` */
+  pageLoading: string;
+  pageEmpty: string;
+  pageError: string;
+  summaryPages: string;
+  summaryPageSize: string;
+  summaryFit: string;
+  summaryFitActual: string;
+  summaryFitWidth: string;
+  summaryZoom: string;
+  fallbackTitle: string;
+  download: string;
+  errorCorrupted: string;
+  errorUnsupported: string;
+  encryptedTitle: string;
+  encryptedMessage: string;
+  encryptedAction: string;
+}
+
+/** Messages consumed by the `image` plugin. */
+export interface ImageMessages {
+  fallbackTitle: string;
+  fallbackMessage: string;
+  download: string;
+  labelFormat: string;
+  labelDimensions: string;
+  labelBitDepth: string;
+  labelColor: string;
+  labelFrames: string;
+  labelImages: string;
+  labelNote: string;
+  noteUnreadableHeader: string;
+  noteUnrecognizedHeader: string;
+  noteJpegMissingSof: string;
+  /** Placeholders: `{chunk}` */
+  noteWebpUnknownChunk: string;
+  noteBmpHeaderTooShort: string;
+  noteTiffIfdOutOfRange: string;
+  tiffEmpty: string;
+  tiffNoImageDirectory: string;
+  tiffIncompletePixels: string;
+  tiffCanvasUnsupported: string;
+  /** Placeholders: `{name}`, `{total}` */
+  tiffPagesLabel: string;
+  /** Placeholders: `{page}`, `{total}`, `{width}`, `{height}` */
+  tiffPageCaption: string;
+  /** Placeholders: `{name}`, `{page}` */
+  tiffPageLabel: string;
+}
+
+/** Messages consumed by the `text` plugin. */
+export interface TextMessages {
+  fallbackTitle: string;
+  fallbackMessage: string;
+  openOriginal: string;
+  plainText: string;
+  /** Placeholders: `{count}` */
+  lines: string;
+  actionWrap: string;
+  actionCopy: string;
+  actionDownload: string;
+  statusCopied: string;
+  statusCopyFailed: string;
+  statusDownloadReady: string;
+  /** Placeholders: `{size}` */
+  truncatedNotice: string;
+  highlightSkippedNotice: string;
+  labelStructure: string;
+  labelEntries: string;
+  labelKeys: string;
+  labelPreview: string;
+  labelTypes: string;
+  labelParsed: string;
+  labelNotebook: string;
+  labelKernel: string;
+  labelNdjson: string;
+  noKeys: string;
+  unknown: string;
+  /** Placeholders: `{count}` */
+  notebookCells: string;
+  /** Placeholders: `{count}` */
+  ndjsonLines: string;
+}
+
+/**
+ * Shape accepted by `PreviewOptions.messages`.
+ *
+ * Every key is optional, and the plugin namespaces are merged one level deep so
+ * that overriding a single key (e.g. `{ pdf: { download: "Save" } }`) keeps the
+ * remaining defaults for that namespace intact.
+ */
+export type PreviewMessagesInput = Partial<Omit<PreviewMessages, "pdf" | "image" | "text">> & {
+  pdf?: Partial<PdfMessages>;
+  image?: Partial<ImageMessages>;
+  text?: Partial<TextMessages>;
+};
 
 export interface PreviewContext {
   host: HTMLElement;


### PR DESCRIPTION
Refs #46

## 动机

我们在一个**全英文产品**里使用 `@open-file-viewer/core`。用户报了两个 bug：

- 预览 xlsx 时，界面显示中文「2 行 x 4 列」；
- 打开一个损坏的 PDF 时，弹出「PDF 预览失败 / 当前浏览器无法加载该 PDF」。

排查后发现：这不是「翻译不全」，而是 **plugin 层根本没有接入 i18n**。已经设置了 `locale: "en-US"`，但 plugin 里的文案是硬编码中文，`locale` 对它们完全不起作用。

## 现状

`0.1.19` 已经有 `locale` + `messages` 的口子，`resolveMessages()` 也默认 `en-US`。但 `PreviewMessages` 只有 **14 个键**（`loading` / `unsupportedTitle` / `downloadTitle` / `downloadFile` / `file` / `unnamedFile` / `format` / `unknown` / `mime` / `undeclared` / `size` / `source` / `remoteUrl` / `localFile`），只服务于 `fallbackPlugin` 那块「不支持预览」的面板。

而 19 个 plugin 里的提示文案全是硬编码中文，合计约 **7000 个中文字符**：

| 模块 | 中文字符数 | | 模块 | 中文字符数 |
|---|---:|---|---|---:|
| `msdoc.ts` | 1791 | | `pdf.ts` | 188 |
| `cad.ts` | 1348 | | `image.ts` | 139 |
| `asset.ts` | 1306 | | `epub.ts` | 111 |
| `office.ts` | 870 | | `audio.ts` | 103 |
| `archive.ts` | 473 | | `text.ts` | 100 |
| `cad-dwg.ts` | 249 | | 其余 | 更少 |

好消息是**渲染管线不用动**：`PreviewContext.options.messages` 本来就是解析好的完整 `PreviewMessages`（见 `types.ts` 的 `PreviewContext`），plugin 直接就能拿到 —— 缺的只是 `PreviewMessages` 里没有 plugin 的键。

## API 设计

### 1. 给 `PreviewMessages` 加命名空间

新增 `pdf` / `image` / `text` 三个子对象（`PdfMessages` / `ImageMessages` / `TextMessages`），zh-CN 与 en-US 两套完整默认值。

### 2. 新增入参类型，支持按单个键覆盖

直接用 `Partial<PreviewMessages>` 的话，用户想改一个键就会把整段 `pdf` 冲掉。所以单独定义入参类型：

```ts
export type PreviewMessagesInput = Partial<Omit<PreviewMessages, "pdf" | "image" | "text">> & {
  pdf?: Partial<PdfMessages>;
  image?: Partial<ImageMessages>;
  text?: Partial<TextMessages>;
};
```

`PreviewOptions.messages` 从 `Partial<PreviewMessages>` 改为 `PreviewMessagesInput`，`resolveMessages()` 对这三个命名空间做一层**深合并**：

```ts
createViewer({
  container,
  file,
  messages: { pdf: { download: "Save a copy" } }
});
// pdf.download 被覆盖，pdf 其余键仍保留 en-US 默认值
```

### 3. 带变量的文案用占位符模板，而不是函数

```ts
pageLoading: "Loading page {page}..."   // 而不是 (page) => `...`
```

另配一个 `formatMessage(template, vars)` 小工具。这样 messages 仍然是**可序列化的纯字符串**，用户可以像普通 i18n 资源一样放进 JSON 语言包。

### 4. `renderPdfDocumentPreview` 保持向后兼容

它是导出的公开 API（`office.ts` / `asset.ts` 也在用），新增可选的 `messages?: PdfMessages`；已有的 `fallbackTitle` / `encryptedTitle` 等口子优先级不变，不传 `messages` 时回落到 en-US 默认值。

顺带把 `office.ts` 和 `asset.ts` 里对它的调用改为透传 `ctx.options.messages.pdf`（各 1～3 行），这样它们内嵌的 PDF 界面也能跟随 `locale`。**这两个文件自身的中文文案没有动**，留待后续。

## ⚠️ 哪些中文不能翻译

这是本次改造最大的坑，也是我认为值得在 PR 里写清楚的地方：**有一部分中文是业务逻辑，不是文案**，一起翻会直接把功能改坏。我自己在过程中就一度改坏过（片段级替换把「格式类型」变成了「Format类型」）。

例如：

```ts
// office.ts —— 识别中文简历的章节结构
text.includes("教育背景" / "专业技能" / "工作经历" / "项目经验" / "自我评价" ...)

// encrypted.ts —— 判断文件是否加密
/\b(password|encrypted|encrypt|protected|decrypt|permission|加密|密码|受保护)\b/i

// 识别中文样式名 / 中文标题 / CJK 字符范围
/^(?:默认段落字体|普通表格|正文|标题|副标题|目录|页眉|页脚|批注|超链接)(?:\s*\d+)?$/
/^(?:标题|第[一二三四五六七八九十\d]+[章节条]|[一二三四五六七八九十\d]+[、.．])/
/[㐀-鿿]/u
```

我采用的判定规则是：

> 出现在 `.includes(` / `.test(` / 正则字面量里的中文 = **逻辑，保留**；
> 写进 DOM（`textContent` / `label` / `createTextNode` / `setAttribute("aria-label", …)`）的 = **文案，翻译**。

本 PR 严格遵守这条规则，上述逻辑用的中文一个都没动。

## 本 PR 范围

**基础设施 + `pdf.ts` / `image.ts` / `text.ts` 三个 plugin 的完整改造。**

`office.ts` 和其余 15 个 plugin **本次不做** —— 套路完全一样，但 `office.test.ts` 有 110KB、106 处中文断言，一起做会让这个 PR 大到没人愿意审。**API 定下来之后，我很乐意在 follow-up 里逐个把剩下的 plugin 跟进完。**

## 测试

- 基线：`npx vitest run packages/core/src/plugins/{pdf,image,text}.test.ts` → 102 passed。
- 这三个测试文件里原有的中文断言（pdf 11 处、image 20 处、text 若干）已改为断言英文，体现默认 `en-US`。
- 新增测试：
  - `messages.test.ts`：`resolveMessages()` 的默认值 / 按 locale 取值 / **深合并**（覆盖单个键时其余键不丢）/ 两个 locale 键集一致；以及 `formatMessage()`。
  - 三个 plugin 各补：`locale: "zh-CN"` 时仍输出中文；`messages: { pdf: { download: "…" } }` 时只覆盖那一个键。
- `render-smoke.test.ts` 里 PDF fallback 的断言同步改为英文。
- 注意：`text.test.ts` 里那些中文是**测试 fixture 数据**（被预览的文件内容，含一个 GBK 解码用例），不是断言文案，未改动。

交付前跑过：

```
pnpm test       → 27 files, 1745 passed (0 failed)
pnpm typecheck  → 全部 Done (exit 0)
pnpm build      → 全部 Build success，新类型已进入 index.d.ts
```

## 后续

如果这个 API 形状 OK，我可以接着提交：

1. 其余 16 个 plugin 的文案迁移（按模块拆成若干个小 PR，方便 review）；
2. README / doc 里补 `locale` + `messages` 的说明（目前 README 完全没有提到这两个选项）。

也很乐意根据你的意见调整命名或结构 —— 比如命名空间的键名、要不要把 `messages` 拆成独立的语言包文件等。
