### PR TITLE
feat(core): toggle fullscreen from the toolbar button

### DIFF
--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -21,6 +21,7 @@ export type PreviewToolbarBuiltInAction =
   | "rotate-right"
   | "download"
   | "fullscreen"
+  | "exit-fullscreen"
   | "print"
   | "search";
 export type PreviewToolbarActionId = PreviewToolbarBuiltInAction | (string & {});
@@ -80,6 +81,7 @@ export interface PreviewToolbarRenderContext {
   viewport: HTMLElement;
   canPrevious: boolean;
   canNext: boolean;
+  isFullscreen: boolean;
   zoom?: number;
   zoomLabel?: string;
   previous: () => Promise<void>;

--- a/packages/core/src/viewer.test.ts
+++ b/packages/core/src/viewer.test.ts
@@ -1142,6 +1142,209 @@ describe("createViewer", () => {
 
     viewer.destroy();
   });
+
+  it("toggles fullscreen from the toolbar and reflects the active state", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    let fullscreenElement: Element | null = null;
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      get: () => fullscreenElement
+    });
+    const exitFullscreen = vi.fn(() => {
+      fullscreenElement = null;
+      return Promise.resolve();
+    });
+    (document as unknown as { exitFullscreen: () => Promise<void> }).exitFullscreen = exitFullscreen;
+
+    try {
+      const viewer = createViewer({
+        container,
+        file: new Blob(["hello"], { type: "text/plain" }),
+        fileName: "hello.txt",
+        toolbar: true,
+        plugins: [
+          {
+            name: "fullscreen-text",
+            match: () => true,
+            render(ctx) {
+              ctx.viewport.textContent = ctx.file.name;
+              return { destroy: vi.fn() };
+            }
+          }
+        ]
+      });
+
+      await waitFor(() => container.textContent?.includes("hello.txt") === true);
+
+      const host = container.querySelector<HTMLElement>(".ofv-host")!;
+      const requestFullscreen = vi.fn(() => {
+        fullscreenElement = host;
+        return Promise.resolve();
+      });
+      host.requestFullscreen = requestFullscreen;
+
+      const button = container.querySelector<HTMLButtonElement>('button[aria-label="Open preview fullscreen"]');
+      expect(button).not.toBeNull();
+      expect(button?.textContent).toBe("Fullscreen");
+      expect(button?.getAttribute("aria-pressed")).toBe("false");
+
+      button?.click();
+      expect(requestFullscreen).toHaveBeenCalledTimes(1);
+
+      document.dispatchEvent(new Event("fullscreenchange"));
+      await waitFor(() => button?.getAttribute("aria-label") === "Exit fullscreen");
+      expect(button?.textContent).toBe("Exit fullscreen");
+      expect(button?.getAttribute("aria-pressed")).toBe("true");
+
+      button?.click();
+      expect(exitFullscreen).toHaveBeenCalledTimes(1);
+
+      document.dispatchEvent(new Event("fullscreenchange"));
+      await waitFor(() => button?.getAttribute("aria-label") === "Open preview fullscreen");
+      expect(button?.textContent).toBe("Fullscreen");
+      expect(button?.getAttribute("aria-pressed")).toBe("false");
+
+      viewer.destroy();
+    } finally {
+      delete (document as unknown as { fullscreenElement?: unknown }).fullscreenElement;
+      delete (document as unknown as { exitFullscreen?: unknown }).exitFullscreen;
+    }
+  });
+
+  it("honors custom labels, titles, and icons for the exit-fullscreen state", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    let fullscreenElement: Element | null = null;
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      get: () => fullscreenElement
+    });
+
+    try {
+      const viewer = createViewer({
+        container,
+        file: new Blob(["hello"], { type: "text/plain" }),
+        fileName: "hello.txt",
+        toolbar: {
+          zoom: false,
+          rotate: false,
+          download: false,
+          print: false,
+          search: false,
+          labels: { fullscreen: "全屏", "exit-fullscreen": "退出全屏" },
+          titles: { fullscreen: "进入全屏", "exit-fullscreen": "退出全屏模式" }
+        },
+        plugins: [
+          {
+            name: "fullscreen-custom",
+            match: () => true,
+            render(ctx) {
+              ctx.viewport.textContent = ctx.file.name;
+              return { destroy: vi.fn() };
+            }
+          }
+        ]
+      });
+
+      await waitFor(() => container.textContent?.includes("hello.txt") === true);
+
+      const host = container.querySelector<HTMLElement>(".ofv-host")!;
+      const button = container.querySelector<HTMLButtonElement>('button[aria-label="进入全屏"]');
+      expect(button?.textContent).toBe("全屏");
+
+      fullscreenElement = host;
+      document.dispatchEvent(new Event("fullscreenchange"));
+
+      await waitFor(() => button?.getAttribute("aria-label") === "退出全屏模式");
+      expect(button?.textContent).toBe("退出全屏");
+
+      viewer.destroy();
+    } finally {
+      delete (document as unknown as { fullscreenElement?: unknown }).fullscreenElement;
+    }
+  });
+
+  it("exposes fullscreen state to custom toolbar renderers", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    let fullscreenElement: Element | null = null;
+    Object.defineProperty(document, "fullscreenElement", {
+      configurable: true,
+      get: () => fullscreenElement
+    });
+
+    try {
+      const viewer = createViewer({
+        container,
+        file: new Blob(["hello"], { type: "text/plain" }),
+        fileName: "hello.txt",
+        toolbar: {
+          render(ctx) {
+            const shell = document.createElement("div");
+            shell.className = "business-toolbar";
+            shell.textContent = ctx.isFullscreen ? "fs:on" : "fs:off";
+            return shell;
+          }
+        },
+        plugins: [
+          {
+            name: "fullscreen-render",
+            match: () => true,
+            render(ctx) {
+              ctx.viewport.textContent = ctx.file.name;
+              return { destroy: vi.fn() };
+            }
+          }
+        ]
+      });
+
+      await waitFor(() => container.querySelector(".business-toolbar")?.textContent === "fs:off");
+
+      const host = container.querySelector<HTMLElement>(".ofv-host")!;
+      fullscreenElement = host;
+      document.dispatchEvent(new Event("fullscreenchange"));
+
+      await waitFor(() => container.querySelector(".business-toolbar")?.textContent === "fs:on");
+
+      viewer.destroy();
+    } finally {
+      delete (document as unknown as { fullscreenElement?: unknown }).fullscreenElement;
+    }
+  });
+
+  it("removes the fullscreenchange listener on destroy", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const addEventListener = vi.spyOn(document, "addEventListener");
+    const removeEventListener = vi.spyOn(document, "removeEventListener");
+
+    const viewer = createViewer({
+      container,
+      file: new Blob(["hello"], { type: "text/plain" }),
+      fileName: "hello.txt",
+      toolbar: true,
+      plugins: [
+        {
+          name: "fullscreen-listener",
+          match: () => true,
+          render(ctx) {
+            ctx.viewport.textContent = "ok";
+            return { destroy: vi.fn() };
+          }
+        }
+      ]
+    });
+
+    expect(addEventListener).toHaveBeenCalledWith("fullscreenchange", expect.any(Function));
+
+    viewer.destroy();
+
+    expect(removeEventListener).toHaveBeenCalledWith("fullscreenchange", expect.any(Function));
+  });
 });
 
 async function waitFor(predicate: () => boolean, timeout = 1000): Promise<void> {

--- a/packages/core/src/viewer.ts
+++ b/packages/core/src/viewer.ts
@@ -375,6 +375,7 @@ function createToolbar(
   let previousButton: HTMLButtonElement | undefined;
   let nextButton: HTMLButtonElement | undefined;
   let zoomResetButton: HTMLButtonElement | undefined;
+  let fullscreenButton: HTMLButtonElement | undefined;
   let currentZoom: number | undefined;
   const commandButtons: Array<{ button: HTMLButtonElement; command: PreviewCommand }> = [];
   const customButtons: Array<{ button: HTMLButtonElement; action: PreviewToolbarCustomAction }> = [];
@@ -497,13 +498,14 @@ function createToolbar(
       return;
     }
     if (id === "fullscreen" && options.fullscreen !== false) {
-      addButton(
+      fullscreenButton = addButton(
         getToolbarLabel(options, id),
         getToolbarTitle(options, id),
         () => getContext().fullscreen(),
         undefined,
         options.icons?.fullscreen
       );
+      updateFullscreenButton();
       return;
     }
     if (id === "print" && options.print) {
@@ -618,6 +620,35 @@ function createToolbar(
     refreshCustomRender();
   }
 
+  function isFullscreenActive(): boolean {
+    return Boolean(
+      typeof document !== "undefined" && element.parentElement && document.fullscreenElement === element.parentElement
+    );
+  }
+
+  function updateFullscreenButton() {
+    if (!fullscreenButton) {
+      return;
+    }
+    const active = isFullscreenActive();
+    const id: PreviewToolbarBuiltInAction = active ? "exit-fullscreen" : "fullscreen";
+    const icon = active ? options.icons?.["exit-fullscreen"] ?? options.icons?.fullscreen : options.icons?.fullscreen;
+    setToolbarButtonContent(fullscreenButton, getToolbarLabel(options, id), icon);
+    const title = getToolbarTitle(options, id);
+    fullscreenButton.title = title;
+    fullscreenButton.setAttribute("aria-label", title);
+    fullscreenButton.setAttribute("aria-pressed", String(active));
+  }
+
+  const handleFullscreenChange = () => {
+    updateFullscreenButton();
+    refreshCustomRender();
+  };
+  if (typeof document !== "undefined") {
+    document.addEventListener("fullscreenchange", handleFullscreenChange);
+    disposers.push(() => document.removeEventListener("fullscreenchange", handleFullscreenChange));
+  }
+
   const refreshCustomRender = () => {
     if (!options.render) {
       return;
@@ -709,6 +740,9 @@ function createToolbarContext({
     viewport,
     canPrevious: index > 0,
     canNext: index < length - 1,
+    isFullscreen: Boolean(
+      typeof document !== "undefined" && element.parentElement && document.fullscreenElement === element.parentElement
+    ),
     zoom,
     zoomLabel: zoom === undefined ? undefined : formatToolbarZoom(zoom),
     async previous() {
@@ -727,7 +761,15 @@ function createToolbarContext({
       }
     },
     fullscreen() {
-      void element.parentElement?.requestFullscreen?.();
+      const target = element.parentElement;
+      if (!target) {
+        return;
+      }
+      if (typeof document !== "undefined" && document.fullscreenElement === target) {
+        void document.exitFullscreen?.();
+      } else {
+        void target.requestFullscreen?.();
+      }
     },
     print() {
       printPreview(viewport);
@@ -747,6 +789,7 @@ const defaultToolbarLabels: Record<PreviewToolbarBuiltInAction, string> = {
   "rotate-right": "Rotate",
   download: "Download",
   fullscreen: "Fullscreen",
+  "exit-fullscreen": "Exit fullscreen",
   print: "Print",
   search: "Search"
 };
@@ -761,6 +804,7 @@ const defaultToolbarTitles: Record<PreviewToolbarBuiltInAction, string> = {
   "rotate-right": "Rotate right",
   download: "Download file",
   fullscreen: "Open preview fullscreen",
+  "exit-fullscreen": "Exit fullscreen",
   print: "Print preview",
   search: "Search preview text"
 };


### PR DESCRIPTION
## Summary
The toolbar Fullscreen button only entered fullscreen and never switched back —
the only way out was the browser's `Esc`. It now toggles: entering fullscreen
flips the button to an "Exit fullscreen" state, and clicking it again (or `Esc`)
leaves fullscreen.

## Changes
- `fullscreen()` now toggles based on `document.fullscreenElement`
  (requestFullscreen vs. exitFullscreen) instead of only requesting.
- The built-in button updates its label / title / icon and `aria-pressed`
  in response to `fullscreenchange`.
- New `exit-fullscreen` key for `labels` / `titles` / `icons` so the exit state
  is customizable (falls back to the fullscreen icon when not provided).
- Expose `ctx.isFullscreen` on the toolbar render context; custom toolbars
  re-render on `fullscreenchange` so they can show their own toggle.
- The `fullscreenchange` listener is removed on `destroy()`.

## Tests
Added cases in `viewer.test.ts`: toggle behavior, custom exit labels/titles,
`ctx.isFullscreen` exposure, and listener cleanup.
`vitest run packages/core/src/viewer.test.ts` → 31 passed.
