### PR TITLE
test(core): 补齐 XMind 冒烟覆盖并修复构建脚本

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "url": "https://github.com/xushanpei/open-file-viewer/issues"
   },
   "scripts": {
-    "build": "pnpm -r --filter ./packages/** build",
+    "build": "pnpm -r --filter \"./packages/**\" build",
     "build:doc": "pnpm --filter @open-file-viewer/doc build",
-    "build:examples": "pnpm -r --filter ./examples/** build",
+    "build:examples": "pnpm -r --filter \"./examples/**\" build",
     "pack:check": "node scripts/check-package-exports.mjs",
     "typecheck": "pnpm -r typecheck",
     "test": "vitest run",

--- a/packages/core/src/plugins/render-smoke.test.ts
+++ b/packages/core/src/plugins/render-smoke.test.ts
@@ -21,6 +21,7 @@ import { ofdPlugin } from "./ofd";
 import { pdfPlugin } from "./pdf";
 import { textPlugin } from "./text";
 import { __setMpegtsLoaderForTests, videoPlugin } from "./video";
+import { xmindPlugin } from "./xmind";
 import { xpsPlugin } from "./xps";
 
 const nativeFetch = globalThis.fetch;
@@ -623,6 +624,7 @@ describe("default plugin render smoke", () => {
         "STEP CAD",
         "WASM data",
         "WebArchive data",
+        "XMind",
         "XPS pages",
         "archive inner text",
         "audio playback",
@@ -3372,6 +3374,16 @@ function toolbarSupportCases(): ToolbarSupportCase[] {
       disabled: ["Rotate right"]
     },
     {
+      name: "XMind",
+      file: minimalXMind,
+      fileName: "toolbar.xmind",
+      plugins: [xmindPlugin()],
+      selector: ".ofv-xmind-workbook",
+      text: "Open File Viewer",
+      enabled: ["Zoom in", "Zoom out", "Reset zoom"],
+      disabled: ["Rotate right"]
+    },
+    {
       name: "GIS map",
       file: new Blob([JSON.stringify({ type: "FeatureCollection", features: [] })], { type: "application/geo+json" }),
       fileName: "toolbar.geojson",
@@ -5053,6 +5065,24 @@ function minimalFlatOdpXml(text: string): string {
 async function minimalZip(): Promise<ArrayBuffer> {
   const zip = new JSZip();
   zip.file("readme.txt", "Hello archive");
+  return zip.generateAsync({ type: "arraybuffer" });
+}
+
+// 构造包含中心主题和分支的最小 XMind 包，用于渲染与 toolbar smoke 覆盖。
+async function minimalXMind(): Promise<ArrayBuffer> {
+  const zip = new JSZip();
+  zip.file(
+    "content.json",
+    JSON.stringify([
+      {
+        title: "Smoke roadmap",
+        rootTopic: {
+          title: "Open File Viewer",
+          children: { attached: [{ title: "XMind preview" }] }
+        }
+      }
+    ])
+  );
   return zip.generateAsync({ type: "arraybuffer" });
 }
 


### PR DESCRIPTION
## 中文说明

### 背景

同步最新 `main` 后发现两个简单且确定的问题：

1. `xmind` 已加入扩展检测和默认插件，但 `render-smoke.test.ts` 的全扩展覆盖门禁仍报告 `xmind` 缺失，导致两项 smoke coverage 测试失败。
2. 根目录 `build` / `build:examples` 脚本中的 pnpm filter glob 未加引号。在 pnpm 11 与当前 shell 下，glob 会先展开为多个目录，pnpm 随后把目录误当作 script 名并报 `ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT`。

### 改动

- 新增最小 XMind `content.json` fixture。
- 将 XMind 纳入 shared toolbar smoke matrix，验证预览渲染以及 `Zoom in`、`Zoom out`、`Reset zoom` 可用，`Rotate right` 禁用。
- 将 XMind 纳入 major preview family 清单，恢复扩展覆盖门禁。
- 为 `./packages/**` 与 `./examples/**` filter glob 加双引号，避免 shell 提前展开。

### 验证

- `NODE_ENV=test pnpm exec vitest run packages/core/src/plugins/render-smoke.test.ts -t 'keeps a render smoke case for every detected extension|keeps shared toolbar smoke coverage for every detected extension|keeps shared toolbar coverage for each major preview family|keeps toolbar command policy explicit for every toolbar support case|exposes the expected shared toolbar commands for XMind' --reporter=dot`：4 项通过。
- `pnpm run typecheck`：通过。
- `pnpm run build`：通过，正确构建 4 个 packages。
- `pnpm run pack:check`：通过。
- `NODE_ENV=test pnpm run test`：29 个 test files、1794 项测试通过；`render-smoke.test.ts` 中 34 项既有 legacy Office smoke case 因 1500ms wait timeout 失败，与本 PR 的 XMind/build script 改动无关。
- `pnpm run build:examples`：修复后已正确选中 4 个 examples；当前大型 Vite bundle 在本机 600 秒内未完成，因此未标记为通过。

---

## English

### Summary

Restore XMind render-smoke coverage and prevent pnpm workspace filter globs from being expanded by the shell.

### Background

After syncing the latest `main`, two deterministic issues were found:

1. `xmind` is registered in extension detection and the default plugin set, but the render-smoke extension gates still reported it as uncovered.
2. The unquoted `./packages/**` and `./examples/**` filters were expanded by the shell under pnpm 11, causing `ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT`.

### Changes

- Add a minimal XMind `content.json` fixture.
- Add XMind to the shared toolbar smoke matrix and major preview-family expectations.
- Verify zoom commands are enabled while rotation remains disabled.
- Quote the package and example workspace filter globs.

### Verification

- Targeted XMind/coverage smoke tests: 4 passed.
- `pnpm run typecheck`: passed.
- `pnpm run build`: passed and selected all 4 package workspaces.
- `pnpm run pack:check`: passed.
- Full `NODE_ENV=test pnpm run test`: 29 test files and 1794 tests passed; 34 pre-existing legacy Office smoke cases still time out in `render-smoke.test.ts`.
- `pnpm run build:examples`: correctly selected all 4 example workspaces after the fix, but the large Vite builds did not finish within 600 seconds on this machine.
