### PR TITLE
fix(core): 修复 Word 预览双滚动条

### DIFF
--- a/packages/core/src/plugins/office.test.ts
+++ b/packages/core/src/plugins/office.test.ts
@@ -908,6 +908,7 @@ describe("officePlugin", () => {
     expect(container.querySelector(".ofv-office-package-note")).toBeNull();
     expect(container.textContent).not.toContain("兼容包识别");
     expect(container.querySelector(".ofv-office-conversion")).toBeNull();
+    expect(container.querySelector(".ofv-office")?.classList.contains("ofv-office-docx")).toBe(true);
     expect(container.querySelector(".ofv-docx-document")?.textContent).toContain("DOCX layout page");
   });
 

--- a/packages/core/src/plugins/office.ts
+++ b/packages/core/src/plugins/office.ts
@@ -534,6 +534,7 @@ async function detectPackagedOfficeFormat(arrayBuffer: ArrayBuffer): Promise<"do
 }
 
 async function renderDocx(panel: HTMLElement, arrayBuffer: ArrayBuffer, fit: PreviewFit): Promise<() => void> {
+  panel.classList.add("ofv-office-docx");
   const content = document.createElement("div");
   content.className = "ofv-docx-document";
   const styleContainer = document.createElement("style");

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -993,6 +993,11 @@
   max-width: 100%;
 }
 
+/* DOCX 纵向滚动统一由 viewport 承担，避免 panel 和文档层重复显示 scrollbar。 */
+.ofv-office-docx {
+  overflow: visible;
+}
+
 .ofv-document {
   overflow-wrap: anywhere;
   font-size: 14px;
@@ -1682,7 +1687,7 @@
   max-width: 100%;
   min-width: 0;
   overflow-x: auto;
-  overflow-y: auto;
+  overflow-y: hidden;
   color: #111827;
 }
 

--- a/packages/core/src/style.test.ts
+++ b/packages/core/src/style.test.ts
@@ -50,6 +50,8 @@ describe("core responsive styles", () => {
     const docxWrapper = rule(".ofv-docx-document .ofv-docx-wrapper");
     const docxSection = rule(".ofv-docx-document section.ofv-docx");
     expect(rule(".ofv-docx-document")).toContain("overflow-x: auto");
+    expect(rule(".ofv-docx-document")).toContain("overflow-y: hidden");
+    expect(rule(".ofv-office-docx")).toContain("overflow: visible");
     expect(docxWrapper).toContain("width: 100%");
     expect(docxWrapper).toContain("max-width: 100%");
     expect(docxWrapper).toContain("overflow: hidden");


### PR DESCRIPTION
## 中文说明

### 背景

Issue #72 报告 Word/DOCX 预览会显示多个垂直滚动条。DOCX 内容当前同时处于 `.ofv-viewport`、`.ofv-panel` 和 `.ofv-docx-document` 三层 `overflow` 容器中，浏览器会为内层容器绘制额外 scrollbar。

### 改动

- 为 DOCX 渲染路径添加 `ofv-office-docx` 语义 class，仅调整 Word/DOCX，不影响 Excel、PowerPoint 等其他 Office 预览。
- 将 DOCX 的纵向滚动统一交给 `.ofv-viewport`，同时保留 `.ofv-docx-document` 的横向滚动能力。
- 增加 Office DOM class 与 CSS overflow regression assertions。

### 验证

- `NODE_ENV=test pnpm exec vitest run packages/core/src/style.test.ts packages/core/src/plugins/office.test.ts`：74 项通过。
- `NODE_ENV=test pnpm exec vitest run packages/core/src/plugins/render-smoke.test.ts -t 'word docx|Word package alias|DOCX'`：16 项通过。
- `pnpm run typecheck`：通过。
- `pnpm run build`：通过。
- 4 个 examples、`pnpm run build:doc` 与 `pnpm run pack:check`：通过。
- Chromium + Playwright 实测：`.ofv-viewport` 是唯一纵向可滚动容器，DOCX 横向滚动保留，文档布局正常。
- 完整 `NODE_ENV=test pnpm run test`：1794 项通过；`render-smoke.test.ts` 中 34 项已知 plain text、PDF fallback 与 legacy Office timeout 仍失败，与本次 DOCX overflow 改动无关；本次相关 DOCX smoke tests 全部通过。

Fixes #72

---

## English

### Summary

Remove duplicate vertical scrollbars from Word/DOCX previews while preserving horizontal scrolling for wide document content.

### Background

DOCX content was nested inside three overflow-enabled layers: `.ofv-viewport`, `.ofv-panel`, and `.ofv-docx-document`. This allowed browsers to render redundant vertical scrollbars.

### Changes

- Add an `ofv-office-docx` class only to the DOCX render path.
- Delegate DOCX vertical scrolling to `.ofv-viewport` while keeping horizontal scrolling on `.ofv-docx-document`.
- Add regression assertions for the DOCX panel class and overflow ownership.

### Verification

- Targeted style and Office tests: 74 passed.
- Targeted DOCX render-smoke tests: 16 passed.
- `pnpm run typecheck`: passed.
- `pnpm run build`: passed.
- All four example builds, documentation build, and package export check: passed.
- Chromium + Playwright confirmed that `.ofv-viewport` is the only vertical scroller, horizontal DOCX scrolling remains available, and document layout is intact.
- Full test run: 1794 passed; 34 known unrelated timeout cases remain in plain text, PDF fallback, and legacy Office render-smoke coverage. All DOCX-related smoke tests passed.

Fixes #72
