### PR TITLE
fix(core): 恢复 Excel 单元格自动换行

### DIFF
--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -2294,7 +2294,7 @@
   position: relative;
   border: 1px solid var(--ofv-border);
   padding: 5px 10px 5px 8px;
-  white-space: nowrap;
+  white-space: normal;
   overflow: hidden;
   overflow-wrap: normal;
   word-break: normal;

--- a/packages/core/src/style.test.ts
+++ b/packages/core/src/style.test.ts
@@ -144,7 +144,7 @@ describe("core responsive styles", () => {
     expect(rule(".ofv-workbook-table td,\n.ofv-workbook-table th")).toContain("padding: 2px 2px 2px 3px");
     expect(rule(".ofv-workbook-table td,\n.ofv-workbook-table th")).toContain("line-height: 1.25");
     expect(rule(".ofv-cell-number")).toContain("text-align: right");
-    expect(rule(".ofv-table-scroll td,\n.ofv-table-scroll th")).toContain("white-space: nowrap");
+    expect(rule(".ofv-table-scroll td,\n.ofv-table-scroll th")).toContain("white-space: normal");
     expect(rule(".ofv-table-scroll td,\n.ofv-table-scroll th")).toContain("overflow-wrap: normal");
     expect(rule(".ofv-table-scroll td,\n.ofv-table-scroll th")).toContain("overflow: hidden");
     expect(rule(".ofv-table-scroll td,\n.ofv-table-scroll th")).toContain("text-overflow: clip");


### PR DESCRIPTION
## 摘要 / Summary

修复 Excel 工作表预览中普通单元格长文本被 `white-space: nowrap` 强制保持单行并裁切的问题。

Fix long Excel cell text being forced onto one line and clipped by the shared `white-space: nowrap` rule.

## 背景 / Background

Issue #76 提供的截图显示，长中文内容在固定列宽内无法自动换行，关闭 `.ofv-table-scroll td, .ofv-table-scroll th` 上的 `white-space: nowrap` 后恢复正常显示。

Issue #76 shows long Chinese content being clipped inside fixed-width cells. Disabling `white-space: nowrap` on `.ofv-table-scroll td, .ofv-table-scroll th` restores wrapping.

## 改动 / Changes

- 将普通表格单元格的 `white-space` 从 `nowrap` 恢复为 `normal`，允许中文按字符间合法断点、含空格文本按空格自动换行。
- 保留 `.ofv-cell-multiline` 的 `pre-wrap` / `overflow-wrap: anywhere`，继续支持显式换行和 Excel `wrapText` 单元格。
- 同步样式回归断言，防止通用 `nowrap` 再次引入。

- Change regular sheet cells from `white-space: nowrap` to `white-space: normal`, allowing CJK text and space-delimited text to wrap at normal break opportunities.
- Preserve `.ofv-cell-multiline` with `pre-wrap` / `overflow-wrap: anywhere` for explicit line breaks and Excel `wrapText` cells.
- Update the style regression assertion to prevent the global `nowrap` behavior from returning.

## 验证 / Verification

通过 / Passed:

- `NODE_ENV=test pnpm exec vitest run packages/core/src/plugins/office.test.ts packages/core/src/style.test.ts` — 74 passed
- `NODE_ENV=test pnpm run typecheck`
- `NODE_ENV=test pnpm run build`
- `NODE_ENV=test pnpm run build:doc`
- React / Vue / Svelte / Vanilla example builds
- `NODE_ENV=test pnpm run pack:check`
- `git diff --check`

完整测试套件中，`render-smoke.test.ts` 有 34 个 `waitFor` 1500ms timeout；移除本补丁后在同一 `origin/main`、同一环境中仍复现完全相同的 34 个失败（816 passed / 34 failed），因此不是本补丁引入的回归。

The full suite reports 34 `waitFor` 1500ms timeouts in `render-smoke.test.ts`. Removing this patch on the same `origin/main` and environment reproduces the exact same 34 failures (816 passed / 34 failed), so they are not introduced by this change.

Fixes #76
