### PR TITLE
fix(core): 兼容 Strict ESM 可选 CAD 依赖

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -71,6 +71,7 @@
     "@types/prismjs": "^1.26.6",
     "@types/three": "^0.184.1",
     "@types/topojson-client": "^3.1.5",
+    "esbuild": "0.27.7",
     "lodash-es": "4.17.21",
     "pdfjs-dist": "^4.10.38"
   },

--- a/packages/core/src/optional-dependencies.test.ts
+++ b/packages/core/src/optional-dependencies.test.ts
@@ -1,0 +1,86 @@
+import { spawn } from "node:child_process";
+import { copyFile, mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { createRequire } from "node:module";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+
+const coreRoot = dirname(fileURLToPath(import.meta.url));
+const workspaceRoot = dirname(dirname(dirname(coreRoot)));
+const require = createRequire(import.meta.url);
+const cadEnginePackageName = "@mlightcad/cad-simple-viewer";
+
+describe("optional CAD module loading", () => {
+  it("bundles the built core without resolving the absent WebGL engine", async () => {
+    const fixtureRoot = await mkdtemp(join(tmpdir(), "ofv-esbuild-"));
+    try {
+      const fixturePackageRoot = join(fixtureRoot, "node_modules", "@open-file-viewer", "core");
+      const entryPath = join(fixtureRoot, "entry.js");
+      const runnerPath = join(fixtureRoot, "run-esbuild.cjs");
+      const resultPath = join(fixtureRoot, "result.json");
+      const esbuildPath = require.resolve("esbuild");
+      const packageJson = JSON.parse(await readFile(join(coreRoot, "../package.json"), "utf8")) as {
+        dependencies: Record<string, string>;
+      };
+
+      await mkdir(join(fixturePackageRoot, "dist"), { recursive: true });
+      await copyFile(join(coreRoot, "../package.json"), join(fixturePackageRoot, "package.json"));
+      await copyFile(join(coreRoot, "../dist/index.js"), join(fixturePackageRoot, "dist/index.js"));
+      await writeFile(entryPath, 'export { cadPlugin } from "@open-file-viewer/core";\n');
+      await writeFile(
+        runnerPath,
+        `const { build } = require(${JSON.stringify(esbuildPath)});
+const [entryPath, outputPath, workspaceRoot, dependencies] = process.argv.slice(2);
+build({
+  absWorkingDir: workspaceRoot,
+  bundle: true,
+  entryPoints: [entryPath],
+  external: JSON.parse(dependencies),
+  format: "esm",
+  logLevel: "silent",
+  packages: "external",
+  platform: "browser",
+  plugins: [{
+    name: "reject-optional-cad-resolution",
+    setup(api) {
+      api.onResolve({ filter: /^@mlightcad\\// }, (args) => ({
+        errors: [{ text: \`Optional CAD package must not be resolved: \${args.path}\` }]
+      }));
+    }
+  }],
+  write: false
+}).then((result) => require("node:fs").writeFileSync(outputPath, JSON.stringify({ code: result.outputFiles[0].text })))
+  .catch((error) => { console.error(error); process.exitCode = 1; });
+`
+      );
+
+      const processResult = await runNode(runnerPath, [
+        entryPath,
+        resultPath,
+        workspaceRoot,
+        JSON.stringify(Object.keys(packageJson.dependencies))
+      ]);
+      expect(processResult.stderr).toBe("");
+      expect(processResult.exitCode).toBe(0);
+
+      const result = JSON.parse(await readFile(resultPath, "utf8")) as { code: string };
+      expect(result.code).not.toContain(`import("${cadEnginePackageName}")`);
+    } finally {
+      await rm(fixtureRoot, { force: true, recursive: true });
+    }
+  });
+});
+
+/** 在独立 Node 进程中运行 esbuild，避免 jsdom 的跨 realm typed array 破坏其启动检查。 */
+function runNode(scriptPath: string, args: string[]): Promise<{ exitCode: number | null; stderr: string }> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [scriptPath, ...args]);
+    let stderr = "";
+    child.stderr.setEncoding("utf8");
+    child.stderr.on("data", (chunk: string) => {
+      stderr += chunk;
+    });
+    child.on("close", (exitCode) => resolve({ exitCode, stderr }));
+  });
+}

--- a/packages/core/src/plugins/cad-webgl.ts
+++ b/packages/core/src/plugins/cad-webgl.ts
@@ -18,12 +18,19 @@ export interface WebglDwgPreviewOptions {
 
 type CadEngineModule = typeof import("@mlightcad/cad-simple-viewer");
 
+const cadEnginePackageName = "@mlightcad/cad-simple-viewer";
+
 let engineModulePromise: Promise<CadEngineModule> | undefined;
 let pendingDestroy: Promise<void> = Promise.resolve();
 
 function loadCadEngine(): Promise<CadEngineModule> {
-  engineModulePromise ??= import("@mlightcad/cad-simple-viewer");
+  // 运行时解析可选 CAD 引擎，避免 Strict ESM bundler 在未安装时中断构建。
+  engineModulePromise ??= importOptionalModule<CadEngineModule>(cadEnginePackageName);
   return engineModulePromise;
+}
+
+function importOptionalModule<T>(packageName: string): Promise<T> {
+  return new Function("packageName", "return import(packageName)")(packageName) as Promise<T>;
 }
 
 export async function renderWebglDwgPreview(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,6 +281,9 @@ importers:
       '@types/topojson-client':
         specifier: ^3.1.5
         version: 3.1.5
+      esbuild:
+        specifier: 0.27.7
+        version: 0.27.7
       lodash-es:
         specifier: 4.17.21
         version: 4.17.21


### PR DESCRIPTION
## 摘要 / Summary

修复 `@open-file-viewer/core` 在未安装可选 `@mlightcad/cad-simple-viewer` 时，被 Strict ESM / esbuild consumer 构建提前中断的问题。

Fix Strict ESM / esbuild consumer builds failing when the optional `@mlightcad/cad-simple-viewer` package is not installed.

## 背景 / Background

WebGL DWG 路径原本使用 literal dynamic import：

```ts
import("@mlightcad/cad-simple-viewer")
```

esbuild、Angular 17+ 等严格 bundler 会在构建期解析这个字面量，即使业务没有配置 `cadPlugin({ webglDwg })`，也会因 optional peer 不存在而报 `Could not resolve`。

The WebGL DWG path used a literal dynamic import. Strict bundlers such as esbuild and Angular 17+ resolve that specifier at build time, so applications that do not enable `cadPlugin({ webglDwg })` could still fail with `Could not resolve` when the optional peer was absent.

## 改动 / Changes

- 沿用项目在 `cad-dwg.ts` 和 `video.ts` 中已有的 optional module runtime loader 模式，在真正启用 WebGL DWG 路径时才解析 CAD engine。
- 保持 `CadEngineModule` 类型检查以及已有模块 Promise 缓存，不改变已安装 engine 时的调用链。
- 增加 built-package esbuild integration regression：
  - 把 core 发布产物复制到不含 optional CAD 包的临时 consumer fixture；
  - 用真实 esbuild 打包；
  - 主动拒绝任何 `@mlightcad/*` build-time resolution；
  - 验证构建通过且产物不再含 literal CAD import。
- 将 `esbuild@0.27.7` 作为 test-only direct devDependency 固定版本，保证回归测试可复现。

- Reuse the repository's existing optional-module runtime loader pattern from `cad-dwg.ts` and `video.ts`, resolving the CAD engine only when the WebGL DWG path is actually enabled.
- Preserve `CadEngineModule` type checking and the existing module-promise cache.
- Add a built-package esbuild integration regression that copies the published core output into a temporary consumer without optional CAD packages, rejects any `@mlightcad/*` build-time resolution, and verifies the bundle succeeds without a literal CAD import.
- Pin `esbuild@0.27.7` as a test-only direct devDependency for reproducible verification.

## 验证 / Verification

通过 / Passed:

- `NODE_ENV=test pnpm exec vitest run packages/core/src/plugins/cad.test.ts packages/core/src/plugins/cad-dwg.test.ts packages/core/src/optional-dependencies.test.ts` — 27 passed
- `NODE_ENV=test pnpm run typecheck`
- `NODE_ENV=test pnpm run build`
- `NODE_ENV=test pnpm run build:doc`
- React / Vue / Svelte example builds
- `NODE_ENV=test pnpm run pack:check`
- `git diff --check`

完整测试套件结果为 1795 passed / 34 failed。34 个失败仍然全部来自 `render-smoke.test.ts` 的 1500ms `waitFor` timeout，与 `origin/main` 已确认的相同 baseline failure 一致。本次修改新增的 Strict ESM integration regression 及全部 CAD 定向测试均通过。

The full suite reached 1795 passed / 34 failed. All 34 failures remain the same 1500ms `waitFor` timeouts in `render-smoke.test.ts`, matching the already confirmed `origin/main` baseline. The new Strict ESM integration regression and all targeted CAD tests pass.

`example-vanilla` build exceeded the local 600-second command limit; the other three example builds and the shared package build passed, and no residual build process remained.

Fixes #79
