### PR TITLE
feat(core): 增加预览支持判断 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,23 @@ import {
 import "@open-file-viewer/core/style.css";
 import pdfWorkerSrc from "pdfjs-dist/build/pdf.worker.mjs?url";
 
+const plugins = [
+  imagePlugin(),
+  videoPlugin(),
+  audioPlugin(),
+  textPlugin(),
+  pdfPlugin({ workerSrc: pdfWorkerSrc }),
+  officePlugin(),
+  archivePlugin(),
+  emailPlugin(),
+  drawingPlugin(),
+  xmindPlugin(),
+  cadPlugin(),
+  model3dPlugin(),
+  gisPlugin(),
+  fallbackPlugin()
+];
+
 const viewer = createViewer({
   container: "#viewer",
   file: fileOrUrl,
@@ -127,27 +144,27 @@ const viewer = createViewer({
   fit: "contain",
   toolbar: true,
   theme: "auto",
-  plugins: [
-    imagePlugin(),
-    videoPlugin(),
-    audioPlugin(),
-    textPlugin(),
-    pdfPlugin({ workerSrc: pdfWorkerSrc }),
-    officePlugin(),
-    archivePlugin(),
-    emailPlugin(),
-    drawingPlugin(),
-    xmindPlugin(),
-    cadPlugin(),
-    model3dPlugin(),
-    gisPlugin(),
-    fallbackPlugin()
-  ]
+  plugins
 });
 
 viewer.resize();
 viewer.destroy();
 ```
+
+Use the same plugin list to check support before mounting a viewer:
+
+```ts
+import { isPreviewSupported } from "@open-file-viewer/core";
+
+const supported = await isPreviewSupported(fileOrUrl, plugins, {
+  fileName: "contract.pdf",
+  mimeType: "application/pdf"
+});
+```
+
+The check normalizes the source exactly like `createViewer()` and evaluates
+`plugin.match()` in order. It does not mount DOM or call `plugin.render()`, and
+`fallbackPlugin()` is not counted as native preview support.
 
 ### Remote PDF fallback compatibility
 

--- a/README.md
+++ b/README.md
@@ -165,6 +165,8 @@ const supported = await isPreviewSupported(fileOrUrl, plugins, {
 The check normalizes the source exactly like `createViewer()` and evaluates
 `plugin.match()` in order. It does not mount DOM or call `plugin.render()`, and
 `fallbackPlugin()` is not counted as native preview support.
+Keep the plugin order identical to the viewer configuration; a matching
+`fallbackPlugin()` is terminal and must not be placed before native plugins.
 
 ### Remote PDF fallback compatibility
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -188,7 +188,8 @@ const supported = await isPreviewSupported(fileOrUrl, plugins, {
 
 该函数与 `createViewer()` 共用文件规范化逻辑，并按顺序调用
 `plugin.match()`；它不会挂载 DOM，也不会调用 `plugin.render()`，且不会把
-`fallbackPlugin()` 计为原生预览支持。
+`fallbackPlugin()` 计为原生预览支持。判断时请保持与 viewer 相同的插件顺序；
+匹配到 `fallbackPlugin()` 后会终止判断，不应将它放在原生插件前。
 
 ### Umi / utoo 中 PDF 预览失败
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -142,6 +142,23 @@ import {
 import "@open-file-viewer/core/style.css";
 import pdfWorkerSrc from "pdfjs-dist/build/pdf.worker.mjs?url";
 
+const plugins = [
+  imagePlugin(),
+  videoPlugin(),
+  audioPlugin(),
+  textPlugin(),
+  pdfPlugin({ workerSrc: pdfWorkerSrc }),
+  officePlugin(),
+  archivePlugin(),
+  emailPlugin(),
+  drawingPlugin(),
+  xmindPlugin(),
+  cadPlugin(),
+  model3dPlugin(),
+  gisPlugin(),
+  fallbackPlugin()
+];
+
 const viewer = createViewer({
   container: "#viewer",
   file: fileOrUrl,
@@ -151,27 +168,27 @@ const viewer = createViewer({
   fit: "contain",
   toolbar: true,
   theme: "auto",
-  plugins: [
-    imagePlugin(),
-    videoPlugin(),
-    audioPlugin(),
-    textPlugin(),
-    pdfPlugin({ workerSrc: pdfWorkerSrc }),
-    officePlugin(),
-    archivePlugin(),
-    emailPlugin(),
-    drawingPlugin(),
-    xmindPlugin(),
-    cadPlugin(),
-    model3dPlugin(),
-    gisPlugin(),
-    fallbackPlugin()
-  ]
+  plugins
 });
 
 viewer.resize();
 viewer.destroy();
 ```
+
+使用同一组插件，可在挂载预览器前判断文件是否有可用预览路径：
+
+```ts
+import { isPreviewSupported } from "@open-file-viewer/core";
+
+const supported = await isPreviewSupported(fileOrUrl, plugins, {
+  fileName: "contract.pdf",
+  mimeType: "application/pdf"
+});
+```
+
+该函数与 `createViewer()` 共用文件规范化逻辑，并按顺序调用
+`plugin.match()`；它不会挂载 DOM，也不会调用 `plugin.render()`，且不会把
+`fallbackPlugin()` 计为原生预览支持。
 
 ### Umi / utoo 中 PDF 预览失败
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -222,6 +222,8 @@ const supported = await isPreviewSupported(fileOrUrl, plugins, {
 The check normalizes the source exactly like `createViewer()` and evaluates
 `plugin.match()` in order. It does not mount DOM or call `plugin.render()`, and
 `fallbackPlugin()` is not counted as native preview support.
+Keep the plugin order identical to the viewer configuration; a matching
+`fallbackPlugin()` is terminal and must not be placed before native plugins.
 
 ### PDF loading compatibility
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -175,6 +175,23 @@ import {
 import "@open-file-viewer/core/style.css";
 import pdfWorkerSrc from "pdfjs-dist/build/pdf.worker.mjs?url";
 
+const plugins = [
+  imagePlugin(),
+  videoPlugin(),
+  audioPlugin(),
+  textPlugin(),
+  pdfPlugin({ workerSrc: pdfWorkerSrc }),
+  officePlugin(),
+  archivePlugin(),
+  emailPlugin(),
+  drawingPlugin(),
+  xmindPlugin(),
+  cadPlugin(),
+  model3dPlugin(),
+  gisPlugin(),
+  fallbackPlugin()
+];
+
 const viewer = createViewer({
   container: "#viewer",
   file: fileOrUrl,
@@ -184,27 +201,27 @@ const viewer = createViewer({
   fit: "contain",
   toolbar: true,
   theme: "auto",
-  plugins: [
-    imagePlugin(),
-    videoPlugin(),
-    audioPlugin(),
-    textPlugin(),
-    pdfPlugin({ workerSrc: pdfWorkerSrc }),
-    officePlugin(),
-    archivePlugin(),
-    emailPlugin(),
-    drawingPlugin(),
-    xmindPlugin(),
-    cadPlugin(),
-    model3dPlugin(),
-    gisPlugin(),
-    fallbackPlugin()
-  ]
+  plugins
 });
 
 viewer.resize();
 viewer.destroy();
 ```
+
+Use the same plugin list to check support before mounting a viewer:
+
+```ts
+import { isPreviewSupported } from "@open-file-viewer/core";
+
+const supported = await isPreviewSupported(fileOrUrl, plugins, {
+  fileName: "contract.pdf",
+  mimeType: "application/pdf"
+});
+```
+
+The check normalizes the source exactly like `createViewer()` and evaluates
+`plugin.match()` in order. It does not mount DOM or call `plugin.render()`, and
+`fallbackPlugin()` is not counted as native preview support.
 
 ### PDF loading compatibility
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,6 @@
 export { createViewer } from "./viewer";
+export { isPreviewSupported } from "./support";
+export type { PreviewSupportOptions } from "./support";
 export { imagePlugin } from "./plugins/image";
 export { videoPlugin } from "./plugins/video";
 export type { VideoPluginOptions } from "./plugins/video";

--- a/packages/core/src/support.test.ts
+++ b/packages/core/src/support.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from "vitest";
+import { fallbackPlugin } from "./plugins/fallback";
+import { isPreviewSupported } from "./support";
+import type { PreviewPlugin } from "./types";
+
+describe("isPreviewSupported", () => {
+  it("checks the configured plugins without mounting a viewer", async () => {
+    const pdfPlugin: PreviewPlugin = {
+      name: "pdf",
+      match: (file) => file.extension === "pdf" || file.mimeType === "application/pdf",
+      render: vi.fn()
+    };
+
+    await expect(isPreviewSupported("https://example.com/report.PDF?download=1", [pdfPlugin])).resolves.toBe(true);
+    expect(pdfPlugin.render).not.toHaveBeenCalled();
+  });
+
+  it("accepts file metadata overrides and rejects unmatched files", async () => {
+    const mimePlugin: PreviewPlugin = {
+      name: "custom-mime",
+      match: (file) => file.mimeType === "application/x-company-document",
+      render: vi.fn()
+    };
+
+    await expect(
+      isPreviewSupported(new ArrayBuffer(0), [mimePlugin], {
+        fileName: "document.bin",
+        mimeType: "application/x-company-document"
+      })
+    ).resolves.toBe(true);
+    await expect(isPreviewSupported(new ArrayBuffer(0), [mimePlugin], { fileName: "document.bin" })).resolves.toBe(false);
+  });
+
+  it("respects plugin order and stops after the first match", async () => {
+    const firstMatch = vi.fn(() => true);
+    const laterMatch = vi.fn(() => true);
+
+    await expect(
+      isPreviewSupported("document.pdf", [
+        { name: "first", match: firstMatch, render: vi.fn() },
+        { name: "later", match: laterMatch, render: vi.fn() }
+      ])
+    ).resolves.toBe(true);
+
+    expect(firstMatch).toHaveBeenCalledTimes(1);
+    expect(laterMatch).not.toHaveBeenCalled();
+  });
+
+  it("does not count the fallback plugin as native preview support", async () => {
+    await expect(isPreviewSupported("archive.unknown", [fallbackPlugin()])).resolves.toBe(false);
+  });
+});

--- a/packages/core/src/support.test.ts
+++ b/packages/core/src/support.test.ts
@@ -49,4 +49,26 @@ describe("isPreviewSupported", () => {
   it("does not count the fallback plugin as native preview support", async () => {
     await expect(isPreviewSupported("archive.unknown", [fallbackPlugin()])).resolves.toBe(false);
   });
+
+  it("treats a matching fallback plugin as terminal", async () => {
+    const nativePlugin: PreviewPlugin = {
+      name: "pdf",
+      match: vi.fn(() => true),
+      render: vi.fn()
+    };
+
+    await expect(isPreviewSupported("document.pdf", [fallbackPlugin(), nativePlugin])).resolves.toBe(false);
+    expect(nativePlugin.match).not.toHaveBeenCalled();
+  });
+
+  it("propagates plugin match errors", async () => {
+    const error = new Error("plugin match failed");
+    const plugin: PreviewPlugin = {
+      name: "broken",
+      match: vi.fn(() => Promise.reject(error)),
+      render: vi.fn()
+    };
+
+    await expect(isPreviewSupported("document.bin", [plugin])).rejects.toBe(error);
+  });
 });

--- a/packages/core/src/support.ts
+++ b/packages/core/src/support.ts
@@ -14,11 +14,9 @@ export async function isPreviewSupported(
 ): Promise<boolean> {
   const file = await normalizeFile(source, options.fileName, options.mimeType);
   for (const plugin of plugins) {
-    if (plugin.name === "fallback") {
-      continue;
-    }
     if (await plugin.match(file)) {
-      return true;
+      // fallback 是终止性的降级路径，命中后不应继续寻找后面的原生插件。
+      return plugin.name !== "fallback";
     }
   }
   return false;

--- a/packages/core/src/support.ts
+++ b/packages/core/src/support.ts
@@ -1,0 +1,25 @@
+import { normalizeFile } from "./detect";
+import type { PreviewPlugin, PreviewSource } from "./types";
+
+export interface PreviewSupportOptions {
+  fileName?: string;
+  mimeType?: string;
+}
+
+/** 在挂载预览器前，按实际插件顺序判断文件是否有可用的预览路径。 */
+export async function isPreviewSupported(
+  source: PreviewSource,
+  plugins: PreviewPlugin[],
+  options: PreviewSupportOptions = {}
+): Promise<boolean> {
+  const file = await normalizeFile(source, options.fileName, options.mimeType);
+  for (const plugin of plugins) {
+    if (plugin.name === "fallback") {
+      continue;
+    }
+    if (await plugin.match(file)) {
+      return true;
+    }
+  }
+  return false;
+}


### PR DESCRIPTION
## 变更说明

### 摘要 / Summary

新增公开的 `isPreviewSupported` API，使宿主应用能在挂载预览器之前，按照实际配置的插件判断文件是否具有原生预览路径。

Add a public `isPreviewSupported` API so host applications can determine whether a file has a native preview path before mounting the viewer, using the plugins they actually configured.

### 背景 / Background

Issue #95 的网盘 / 文件管理器场景需要在挂载 DOM 前决定打开预览、直接下载或显示业务降级 UI。由宿主自行维护扩展名集合会与 core 的插件、MIME 和文件名识别规则逐渐漂移。

Issue #95 needs a pre-mount decision between preview, download, and a custom fallback UI. A host-maintained extension set can drift from the core plugin, MIME, and filename detection rules.

### 改动 / Changes

- 新增 `isPreviewSupported(source, plugins, options?)`，复用 `createViewer()` 的文件规范化逻辑。
- 按调用方提供的插件顺序执行异步 `plugin.match()`，首个匹配后立即返回。
- 明确排除 `fallbackPlugin()`，避免把下载/降级路径误报为原生预览支持。
- 支持通过 `fileName` 和 `mimeType` 覆盖远程 URL、`Blob`、`File` 或 `ArrayBuffer` 的元数据。
- 从 `@open-file-viewer/core` 公共入口导出函数和 `PreviewSupportOptions` 类型，并补充中英文文档。
- 增加回归测试，覆盖 URL 规范化、MIME 覆盖、不匹配、插件顺序、无 DOM render 和 fallback 排除。

- Add `isPreviewSupported(source, plugins, options?)` using the same file normalization as `createViewer()`.
- Evaluate asynchronous `plugin.match()` functions in caller-provided order and stop at the first match.
- Exclude `fallbackPlugin()` so a download/fallback route is not reported as native preview support.
- Support `fileName` and `mimeType` overrides for URL, `Blob`, `File`, and `ArrayBuffer` sources.
- Export the function and `PreviewSupportOptions` from the public core entry, with Chinese and English documentation.
- Add regressions for URL normalization, MIME overrides, unmatched files, plugin ordering, no DOM render, and fallback exclusion.

## 关联 Issue

Fixes #95

> Review follow-up: a matching `fallbackPlugin()` is terminal, so support detection now stays aligned with `createViewer()` even when fallback appears before native plugins.

## 验证结果

- [x] 已运行与本次变更相关的测试或检查
- [x] 已使用真实文件验证修改后的预览效果
- [x] 本次修改不包含无关变更

通过 / Passed：

- `NODE_ENV=test pnpm run test` — 35 files, **1872 passed**
- `pnpm run typecheck`
- `pnpm run build`
- React / Vue / Svelte / Vanilla 四个 example build
- `pnpm run build:doc`
- `pnpm run pack:check`
- built `dist` runtime smoke: `report.pdf => true`, `archive.unknown => false`
- `git diff --check`
- Chrome DevTools：构建后的文档站真实启动并预览成功；Console 无 error/warn，仅有一个既有 form-field issue

## 预览成功截图

![pr-95-preview.png](https://github.com/user-attachments/assets/312c4ca0-b832-48ea-8481-b8c12eb111c9)

- [x] 截图来自本次变更的实际预览结果