### PR TITLE
fix(ofd): preserve TextCode leading spaces

### DIFF
--- a/packages/core/src/plugins/ofd.test.ts
+++ b/packages/core/src/plugins/ofd.test.ts
@@ -487,6 +487,40 @@ describe("ofdPlugin", () => {
     expect(texts[1]?.getAttribute("text-anchor")).toBeNull();
   });
 
+  it("preserves leading TextCode spaces when DeltaX positions the text", async () => {
+    const zip = new JSZip();
+    zip.file(
+      "Doc_0/Pages/Page_0/Content.xml",
+      `<ofd:Page xmlns:ofd="http://www.ofdspec.org/2016">
+        <ofd:Content>
+          <ofd:Layer>
+            <ofd:TextObject Boundary="76 250 40 8" Size="4">
+              <ofd:TextCode X="0" Y="4" DeltaX="5 6 7">  25</ofd:TextCode>
+            </ofd:TextObject>
+          </ofd:Layer>
+        </ofd:Content>
+      </ofd:Page>`
+    );
+    const buffer = await zip.generateAsync({ type: "arraybuffer" });
+    const container = document.createElement("div");
+    document.body.append(container);
+
+    createViewer({
+      container,
+      file: buffer,
+      fileName: "leading-spaces.ofd",
+      plugins: [ofdPlugin()]
+    });
+
+    await waitFor(() => Boolean(container.querySelector(".ofv-ofd-pages svg")));
+
+    const text = container.querySelector(".ofv-ofd-page text");
+    const spans = text?.querySelectorAll("tspan");
+    expect(text?.textContent).toBe("  25");
+    expect(spans).toHaveLength(4);
+    expect(spans?.[2]?.getAttribute("x")).toBe("87");
+  });
+
   it("decodes escaped TextCode characters instead of rendering escape sequences", async () => {
     const zip = new JSZip();
     zip.file(

--- a/packages/core/src/plugins/ofd.ts
+++ b/packages/core/src/plugins/ofd.ts
@@ -409,7 +409,9 @@ function parseOfdTextObject(element: Element, resources: OfdPageResources): OfdT
     // CTM 存在时坐标保持相对 Boundary，由 transform 完成平移与矩阵变换
     const x = (transform ? 0 : boundary.x) + finiteNumber(getOfdAttribute(code, "X"), 0);
     const y = (transform ? 0 : boundary.y) + finiteNumber(getOfdAttribute(code, "Y"), 0);
-    const text = decodeOfdTextEscapes(code.textContent?.trim() || "");
+    // TextCode whitespace is layout data. In particular, leading spaces can
+    // carry explicit DeltaX positions before a trailing date or number.
+    const text = decodeOfdTextEscapes(code.textContent || "");
     const deltaX = parseOfdDeltaX(getOfdAttribute(code, "DeltaX"));
     const deltaY = getOfdAttribute(code, "DeltaY");
     if (deltaY && text.length > 1) {


### PR DESCRIPTION
## 变更说明

OFD `TextCode` 的前导空格属于 `DeltaX` 排版数据。原实现对文本调用 `.trim()`，会删除这些空格并使页脚中的 `2025` 左移。

本次修改保留 `TextCode` 原始空白，并增加回归测试验证前导空格、`DeltaX` 与数字定位。

## 关联 Issue

Fixes #97

## 验证结果

- [x] `pnpm exec vitest run packages/core/src/plugins/ofd.test.ts`（24/24）
- [x] `pnpm --filter @open-file-viewer/core typecheck`
- [x] 使用 Issue 附件 `333.ofd` 验证第 10 页页脚间距
- [x] `git diff --check`

- [x] 已运行与本次变更相关的测试或检查
- [x] 已使用真实文件验证修改后的预览效果
- [x] 本次修改不包含无关变更

## 预览成功截图

- [ ] 截图来自本次变更的实际预览结果