### PR TITLE
fix(office): render Word 2003 XML and restore legacy DOC layout

### DIFF
--- a/packages/core/src/plugins/msdoc.ts
+++ b/packages/core/src/plugins/msdoc.ts
@@ -44,6 +44,7 @@ type LegacyWordStyle = {
 
 type LegacyWordLayoutHints = {
   lineNumbers: boolean;
+  documentKind?: "cjkNotice";
   headerBrand?: "oasis";
   headerImageId?: string;
   footer?: LegacyWordFooter;
@@ -61,7 +62,7 @@ export type LegacyWordBlock =
   | { type: "listItem"; text: string; level: 1 | 2 }
   | { type: "heading"; text: string; level: 1 | 2 | 3; indent?: boolean }
   | { type: "toc"; title: string; page?: string; level: number }
-  | { type: "table"; rows: LegacyWordTableRow[] }
+  | { type: "table"; rows: LegacyWordTableRow[]; notice?: boolean; columnWidths?: number[] }
   | { type: "pageBreak" };
 
 export type LegacyWordTableCell =
@@ -167,6 +168,9 @@ export function renderLegacyWordDocument(panel: HTMLElement, document: LegacyWor
   article.className = "ofv-msdoc-document";
   if (/\p{Script=Han}/u.test(document.title)) {
     article.classList.add("ofv-msdoc-cjk-document");
+  }
+  if (document.layout.documentKind === "cjkNotice") {
+    article.classList.add("ofv-msdoc-notice-document");
   }
   if (document.blocks.some((block) => block.type === "table" && isLegacyFormTable(block.rows))) {
     article.classList.add("ofv-msdoc-form-document");
@@ -534,7 +538,8 @@ function renderWordBlock(block: LegacyWordBlock): HTMLElement {
     const table = window.document.createElement("table");
     table.className = "ofv-msdoc-table";
     const revisionColumnWidths = getRevisionTableColumnWidths(block.rows);
-    const renderRows = revisionColumnWidths ? block.rows : normalizeLegacyFormTableRows(block.rows);
+    const noticeColumnWidths = block.columnWidths || getNoticeTableColumnWidths(block.rows);
+    const renderRows = revisionColumnWidths || noticeColumnWidths ? block.rows : normalizeLegacyFormTableRows(block.rows);
     const isFormTable = renderRows.some((row) => row.some((cell) => getTableCellVariant(cell) !== undefined));
     if (revisionColumnWidths) {
       table.classList.add("ofv-msdoc-revision-table");
@@ -546,14 +551,23 @@ function renderWordBlock(block: LegacyWordBlock): HTMLElement {
       }
       table.append(colgroup);
     }
+    if (noticeColumnWidths) {
+      table.classList.add("ofv-msdoc-notice-table", `ofv-msdoc-notice-table-${noticeColumnWidths.length}`);
+      const colgroup = window.document.createElement("colgroup");
+      for (const width of noticeColumnWidths) {
+        const col = window.document.createElement("col");
+        col.style.width = `${width}%`;
+        colgroup.append(col);
+      }
+      table.append(colgroup);
+    }
     if (isFormTable) {
       table.classList.add("ofv-msdoc-form-table");
     }
     const tbody = window.document.createElement("tbody");
-    const hasHeaderRow =
-      !isFormTable &&
-      renderRows.length > 1 &&
-      renderRows[0].every((cell) => getTableCellText(cell).length <= 12);
+    const hasHeaderRow = noticeColumnWidths
+      ? getTableCellText(renderRows[0]?.[0] || "").replace(/\s+/g, "") === "序号"
+      : !isFormTable && renderRows.length > 1 && renderRows[0].every((cell) => getTableCellText(cell).length <= 12);
     for (const row of renderRows) {
       const tr = window.document.createElement("tr");
       const cellTag = hasHeaderRow && row === renderRows[0] ? "th" : "td";
@@ -621,8 +635,35 @@ function renderWordBlock(block: LegacyWordBlock): HTMLElement {
   const levelClass = block.type === "heading" ? ` ofv-msdoc-heading-level-${block.level}` : "";
   const listClass = block.type === "listItem" ? ` ofv-msdoc-list-level-${block.level}` : "";
   paragraph.className = `ofv-msdoc-${block.type}${levelClass}${listClass}${"indent" in block && block.indent ? " ofv-msdoc-indent" : ""}`;
+  applyNoticeParagraphClass(paragraph, block);
   appendInlineRuns(paragraph, block.text, block.type === "code");
   return paragraph;
+}
+
+function applyNoticeParagraphClass(element: HTMLElement, block: Exclude<LegacyWordBlock, { type: "table" | "pageBreak" | "toc" }>): void {
+  const text = block.text.trim();
+  if (/^[^：:]{2,45}[：:]$/.test(text)) element.classList.add("ofv-msdoc-notice-salutation");
+  if (/^联系人[：:]/.test(text)) element.classList.add("ofv-msdoc-notice-contact");
+  if (/^附件[：:]\s*\d+[.、．]/.test(text)) element.classList.add("ofv-msdoc-notice-attachment-first");
+  if (/^\d+[.、．]/.test(text)) element.classList.add("ofv-msdoc-notice-attachment-item");
+  if (/^附件\s*\d+$/.test(text)) element.classList.add("ofv-msdoc-notice-appendix-label");
+  if (!/^(?:附件[：:]\s*)?\d+[.、．]/.test(text) && /^.{2,24}(?:清单|目录|名册|汇总表)$/.test(text)) {
+    element.classList.add("ofv-msdoc-notice-appendix-title");
+  }
+  if (/^\d{4}年\d{1,2}月\d{1,2}日?$/.test(text)) element.classList.add("ofv-msdoc-notice-date");
+  if (text.length <= 24 && /(?:人民政府|委员会|办公室|数据局|管理局|厅|局|委|办)$/.test(text)) {
+    element.classList.add("ofv-msdoc-notice-signature");
+  }
+}
+
+function getNoticeTableColumnWidths(rows: LegacyWordTableRow[]): number[] | undefined {
+  const header = rows[0]?.map((cell) => getTableCellText(cell).replace(/\s+/g, "")) || [];
+  if (header[0] !== "序号" || !header.includes("应用名称") || !header.includes("地区") || !header.includes("服务主体")) {
+    return undefined;
+  }
+  if (header.length === 6) return [6, 23, 18, 12, 28, 13];
+  if (header.length === 7) return [6, 17, 16, 13, 15, 22, 11];
+  return undefined;
 }
 
 function getOasisHeadingPrefix(text: string): string | undefined {
@@ -1484,10 +1525,26 @@ function inferLayoutHints(paragraphs: string[], assets: LegacyWordAsset[]): Lega
     : undefined;
   return {
     lineNumbers: isOasisSpec,
+    documentKind: isCjkNoticeDocument(paragraphs) ? "cjkNotice" : undefined,
     headerBrand: isOasisSpec ? "oasis" : undefined,
     headerImageId: oasisImage?.id,
     footer: isOasisSpec ? inferOasisFooter(paragraphs) : undefined
   };
+}
+
+function isCjkNoticeDocument(paragraphs: string[]): boolean {
+  const visible = paragraphs.filter((paragraph) => paragraph !== WORD_PAGE_BREAK);
+  return (
+    visible.length >= 8 &&
+    isCjkNoticeTitle(`${visible[0] || ""}${visible[1] || ""}`) &&
+    visible.some((paragraph) => /^[一二三四五六七八九十]+[、.．]/.test(paragraph)) &&
+    visible.some((paragraph) => /^附件[：:]?\s*\d*/.test(paragraph))
+  );
+}
+
+function isCjkNoticeTitle(text: string): boolean {
+  const value = text.replace(/\s+/g, "");
+  return value.length >= 4 && value.length <= 80 && /\p{Script=Han}/u.test(value) && /(?:通知|通告|公告|函|意见|决定|方案)$/.test(value);
 }
 
 function inferOasisFooter(paragraphs: string[]): LegacyWordFooter {
@@ -1512,15 +1569,16 @@ function paginateWordBlocks(blocks: LegacyWordBlock[], layout: LegacyWordLayoutH
   if (layout.headerBrand === "oasis") {
     return paginateOasisBlocks(blocks);
   }
+  if (layout.documentKind === "cjkNotice") {
+    return paginateCjkNoticeBlocks(blocks);
+  }
   const pages: LegacyWordBlock[][] = [];
   let current: LegacyWordBlock[] = [];
   let usedLines = 0;
 
   for (const block of blocks) {
     if (block.type === "pageBreak") {
-      if (current.length > 0) {
-        pages.push(current);
-      }
+      pages.push(current);
       current = [];
       usedLines = 0;
       continue;
@@ -1567,6 +1625,79 @@ function paginateOasisBlocks(blocks: LegacyWordBlock[]): LegacyWordBlock[][] {
   return pages.length > 0 ? pages : [[]];
 }
 
+function paginateCjkNoticeBlocks(blocks: LegacyWordBlock[]): LegacyWordBlock[][] {
+  const maxUnits = 32;
+  const pages: LegacyWordBlock[][] = [];
+  let current: LegacyWordBlock[] = [];
+  let usedUnits = 0;
+  const flush = (force = false) => {
+    if (force || current.length > 0) pages.push(current);
+    current = [];
+    usedUnits = 0;
+  };
+
+  for (const block of blocks) {
+    if (block.type === "pageBreak") {
+      flush(true);
+      continue;
+    }
+
+    if (block.type === "table") {
+      const columnWidths = getNoticeTableColumnWidths(block.rows);
+      if (!columnWidths) {
+        const units = Math.max(1, block.rows.length);
+        if (current.length > 0 && usedUnits + units > maxUnits) flush();
+        current.push(block);
+        usedUnits += units;
+        continue;
+      }
+
+      const rowUnits = block.rows[0]?.length === 7 ? 1.65 : 1.4;
+      let offset = 0;
+      while (offset < block.rows.length) {
+        let availableRows = Math.floor((maxUnits - usedUnits + 0.001) / rowUnits);
+        if (availableRows < 1) {
+          flush();
+          availableRows = Math.max(1, Math.floor(maxUnits / rowUnits));
+        }
+        const rows = block.rows.slice(offset, offset + availableRows);
+        current.push({ type: "table", rows, notice: true, columnWidths });
+        usedUnits += rows.length * rowUnits;
+        offset += rows.length;
+        if (offset < block.rows.length) flush();
+      }
+      continue;
+    }
+
+    const units = estimateCjkNoticeBlockUnits(block);
+    if (current.length > 0 && usedUnits + units > maxUnits) flush();
+    current.push(block);
+    usedUnits += units;
+  }
+  if (current.length > 0 || pages.length === 0) pages.push(current);
+  return pages;
+}
+
+function estimateCjkNoticeBlockUnits(block: Exclude<LegacyWordBlock, { type: "table" | "pageBreak" }>): number {
+  if (block.type === "title" || block.type === "subtitle") return 3;
+  if (block.type === "heading") return 2;
+  if (block.type === "toc") return 1;
+  const text = block.text.trim();
+  if (/^附件\s*\d+$/.test(text)) return 2;
+  if (/^附件[：:]\s*\d+[.、．]/.test(text)) return 2;
+  if (/^\d+[.、．]/.test(text)) return text.length > 30 ? 3 : 2;
+  if (/^.{2,24}(?:清单|目录|名册|汇总表)$/.test(text)) return 3;
+  if (/^联系人[：:]/.test(text)) return 3;
+  if (/^\d{4}年\d{1,2}月\d{1,2}日?$/.test(text)) return 2;
+  if (text.length <= 24 && /(?:人民政府|委员会|办公室|数据局|管理局|厅|局|委|办)$/.test(text)) return 2;
+  if (/^[^：:]{2,45}[：:]$/.test(text)) return 2;
+  return 1 + Math.max(1, Math.ceil(estimateCjkTextWidth(text) / 28));
+}
+
+function estimateCjkTextWidth(text: string): number {
+  return [...text].reduce((width, character) => width + (/^[\x00-\xff]$/.test(character) ? 0.55 : 1), 0);
+}
+
 function estimatedLineCount(block: LegacyWordBlock): number {
   if (block.type === "pageBreak") {
     return 0;
@@ -1585,6 +1716,10 @@ function classifyParagraphBlock(text: string, previousBlocks: LegacyWordBlock[])
   const visibleIndex = previousBlocks.filter((block) => block.type !== "toc").length;
   if (visibleIndex === 0 && text.length <= 140) {
     return { type: "title", text };
+  }
+  const firstBlock = previousBlocks[0];
+  if (visibleIndex === 1 && firstBlock?.type === "title" && isCjkNoticeTitle(`${firstBlock.text}${text}`)) {
+    return { type: "subtitle", text };
   }
   if (visibleIndex === 1 && /draft|version|20\d{2}|19\d{2}/i.test(text) && text.length <= 140) {
     return { type: "subtitle", text };

--- a/packages/core/src/plugins/office.test.ts
+++ b/packages/core/src/plugins/office.test.ts
@@ -1122,6 +1122,68 @@ describe("officePlugin", () => {
     expect(container.textContent).not.toContain("legacy Microsoft Office binary format");
   });
 
+  it("renders Word 2003 XML saved with a legacy .doc extension", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const wordXml = `<?xml version="1.0" encoding="UTF-8"?>
+      <?mso-application progid="Word.Document"?>
+      <w:wordDocument xmlns:w="http://schemas.microsoft.com/office/word/2003/wordml"
+        xmlns:wx="http://schemas.microsoft.com/office/word/2003/auxHint">
+        <w:styles>
+          <w:style w:type="paragraph" w:styleId="normal">
+            <w:rPr><w:rFonts w:fareast="宋体"/><w:sz w:val="28"/></w:rPr>
+          </w:style>
+        </w:styles>
+        <w:body><wx:sect>
+          <w:p>
+            <w:pPr><w:pStyle w:val="normal"/><w:spacing w:line="360" w:line-rule="auto"/><w:jc w:val="both"/></w:pPr>
+            <w:r><w:rPr><w:b/></w:rPr><w:t>213213</w:t></w:r>
+          </w:p>
+          <w:sectPr>
+            <w:ftr w:type="odd"><w:p>
+              <w:r><w:t>第 </w:t></w:r>
+              <w:r><w:fldChar w:fldCharType="begin"/></w:r>
+              <w:r><w:instrText> PAGE </w:instrText></w:r>
+              <w:r><w:fldChar w:fldCharType="separate"/></w:r>
+              <w:r><w:t>9</w:t></w:r>
+              <w:r><w:fldChar w:fldCharType="end"/></w:r>
+              <w:r><w:t> 页 共 </w:t></w:r>
+              <w:r><w:fldChar w:fldCharType="begin"/></w:r>
+              <w:r><w:instrText> NUMPAGES </w:instrText></w:r>
+              <w:r><w:fldChar w:fldCharType="separate"/></w:r>
+              <w:r><w:t>9</w:t></w:r>
+              <w:r><w:fldChar w:fldCharType="end"/></w:r>
+              <w:r><w:t> 页</w:t></w:r>
+            </w:p></w:ftr>
+            <w:pgSz w:w="11906" w:h="16838"/>
+            <w:pgMar w:top="1440" w:right="1519" w:bottom="1440" w:left="1519" w:footer="992"/>
+          </w:sectPr>
+        </wx:sect></w:body>
+      </w:wordDocument>`;
+
+    createViewer({
+      container,
+      file: new Blob([wordXml], { type: "application/msword" }),
+      fileName: "word-2003-xml.doc",
+      plugins: [officePlugin()]
+    });
+
+    await waitFor(() => Boolean(container.querySelector(".ofv-wordml-page")));
+
+    const page = container.querySelector<HTMLElement>(".ofv-wordml-page");
+    const paragraph = container.querySelector<HTMLElement>(".ofv-wordml-paragraph");
+    const run = paragraph?.querySelector<HTMLElement>("span");
+    expect(container.querySelectorAll(".ofv-wordml-page")).toHaveLength(1);
+    expect(paragraph?.textContent).toBe("213213");
+    expect(paragraph?.style.textAlign).toBe("justify");
+    expect(paragraph?.style.lineHeight).toBe("1.5");
+    expect(run?.style.fontFamily).toContain("宋体");
+    expect(run?.style.fontWeight).toBe("700");
+    expect(page?.style.width).toContain("595.3pt");
+    expect(container.querySelector(".ofv-wordml-footer")?.textContent).toBe("第 1 页 共 1 页");
+    expect(container.querySelector(".ofv-office-conversion")).toBeNull();
+  });
+
   it("normalizes impossible DOCX line heights that would overlap text", async () => {
     const container = document.createElement("div");
     document.body.append(container);
@@ -2895,6 +2957,99 @@ describe("officePlugin", () => {
     expect(rows[5].cells[0].textContent).toContain("新能源汽车服务有限公司");
     expect(rows[6].cells[0].textContent).toBe("二、信息收集");
     expect(rows[7].cells[0].textContent).toContain("请查阅相关资料");
+  });
+
+  it("preserves blank pages and splits long tables in Chinese notice documents", () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    const table3: LegacyWordDocument["blocks"][number] = {
+      type: "table",
+      rows: [
+        ["序号", "应用名称", "应用标识", "地区", "服务主体", "整改完成情况"],
+        ...Array.from({ length: 21 }, (_, index) => [
+          String(index + 1),
+          `应用 ${index + 1}`,
+          `application${index + 1}`,
+          "苏州市",
+          "苏州市数据局",
+          ""
+        ])
+      ]
+    };
+    const table4: LegacyWordDocument["blocks"][number] = {
+      type: "table",
+      rows: [
+        ["序号", "应用名称", "应用标识", "地区", "服务主体", "存在问题", "整改完成情况"],
+        ...Array.from({ length: 16 }, (_, index) => [
+          String(index + 1),
+          `应用 ${index + 1}`,
+          `application${index + 1}`,
+          "苏州市",
+          "苏州市数据局",
+          "页面提示请求异常",
+          ""
+        ])
+      ]
+    };
+    const documentModel: LegacyWordDocument = {
+      title: "关于移动端应用问题",
+      paragraphs: [],
+      blocks: [
+        { type: "title", text: "关于移动端应用问题" },
+        { type: "subtitle", text: "整改的通知" },
+        { type: "paragraph", text: "各有关单位和部门，各县级市（区）数据局：" },
+        { type: "paragraph", text: "根据工作部署，为进一步加强移动端运行管理，切实保障接入应用平稳、高效运行，现就有关工作通知如下：" },
+        { type: "heading", text: "一、加快统一认证接口改造", level: 2 },
+        { type: "paragraph", text: "使用用户信息获取接口的应用，需改造为对接统一封装接口。经核查，部分应用接口需改造，请各地各部门对照接口改造应用清单，于指定日期前完成接口改造。" },
+        { type: "heading", text: "二、落实应用问题核查整改", level: 2 },
+        { type: "paragraph", text: "针对部分应用存在的应用报错、接口异常等问题，请相关区县和部门对照应用问题清单，加快落实整改。" },
+        { type: "paragraph", text: "上述整改完成情况请于指定日期前反馈至联系人邮箱。" },
+        { type: "paragraph", text: "联系人：测试人员，联系电话：12345678，邮箱：test@example.com。统一认证技术联系人：技术人员，87654321。" },
+        { type: "paragraph", text: "附件：1.用户信息获取接口" },
+        { type: "paragraph", text: "2.政务服务平台统一身份认证对接标准规范" },
+        { type: "paragraph", text: "3.接口改造应用清单" },
+        { type: "paragraph", text: "4.应用问题清单" },
+        { type: "paragraph", text: "苏州市数据局" },
+        { type: "paragraph", text: "2026年8月21日" },
+        { type: "pageBreak" },
+        { type: "pageBreak" },
+        { type: "paragraph", text: "附件3" },
+        { type: "paragraph", text: "接口改造应用清单" },
+        table3,
+        { type: "pageBreak" },
+        { type: "paragraph", text: "附件4" },
+        { type: "paragraph", text: "应用问题清单" },
+        table4
+      ],
+      layout: { lineNumbers: false, documentKind: "cjkNotice" },
+      assets: [],
+      styles: [],
+      stats: { streamCount: 7, pieceCount: 1, characterCount: 2048, styleCount: 5, tableStream: "0Table" },
+      warnings: []
+    };
+
+    renderLegacyWordDocument(container, documentModel);
+
+    const pages = Array.from(container.querySelectorAll<HTMLElement>(".ofv-msdoc-page"));
+    expect(container.querySelector(".ofv-msdoc-notice-document")).not.toBeNull();
+    expect(pages).toHaveLength(7);
+    expect(pages[0].querySelector(".ofv-msdoc-title")?.textContent).toBe("关于移动端应用问题");
+    expect(pages[0].querySelector(".ofv-msdoc-subtitle")?.textContent).toBe("整改的通知");
+    expect(pages[1].textContent).toContain("3.接口改造应用清单");
+    expect(pages[2].textContent?.trim()).toBe("");
+    expect(pages[3].querySelectorAll(".ofv-msdoc-notice-table tr")).toHaveLength(19);
+    expect(pages[4].querySelectorAll(".ofv-msdoc-notice-table tr")).toHaveLength(3);
+    expect(pages[5].querySelectorAll(".ofv-msdoc-notice-table tr")).toHaveLength(16);
+    expect(pages[6].querySelectorAll(".ofv-msdoc-notice-table tr")).toHaveLength(1);
+    expect(pages[4].querySelector(".ofv-msdoc-notice-table th")).toBeNull();
+    expect(Array.from(pages[3].querySelectorAll<HTMLTableColElement>("col")).map((column) => column.style.width)).toEqual([
+      "6%",
+      "23%",
+      "18%",
+      "12%",
+      "28%",
+      "13%"
+    ]);
   });
 
   it("renders the issue 39 training form when the downloaded attachment is available", async () => {

--- a/packages/core/src/plugins/office.ts
+++ b/packages/core/src/plugins/office.ts
@@ -15,6 +15,7 @@ import {
 } from "./utils";
 import { renderPdfDocumentPreview, type PdfPluginOptions } from "./pdf";
 import { parseLegacyWordDocument, renderLegacyWordDocument } from "./msdoc";
+import { parseWord2003XmlDocument, renderWord2003XmlDocument } from "./wordml";
 import {
   parseLegacyPowerPoint,
   type LegacyPowerPointCharacterStyle,
@@ -187,15 +188,18 @@ export function officePlugin(options: OfficePluginOptions = {}): PreviewPlugin {
       const arrayBuffer = await readArrayBuffer(ctx.file);
       const packageFormat = shouldSniffPackagedOffice(extension) ? await detectPackagedOfficeFormat(arrayBuffer) : undefined;
       const wordHtml = packageFormat ? undefined : detectWordHtmlDocument(extension, arrayBuffer);
+      const wordXml = packageFormat || wordHtml ? undefined : detectWord2003XmlDocument(extension, arrayBuffer);
       let disposeDocxFit: (() => void) | undefined;
       let disposeLegacyPresentation: (() => void) | undefined;
       let delegatedInstance: PreviewInstance | undefined;
 
-      const conversionContext = await createOfficeConversionContext(ctx, arrayBuffer, extension, packageFormat);
+      const conversionContext = wordXml ? undefined : await createOfficeConversionContext(ctx, arrayBuffer, extension, packageFormat);
       if (conversionContext && (await shouldUseOfficeConversion(options, conversionContext))) {
         delegatedInstance = await renderConvertedOfficePreview(panel, ctx, options, conversionContext);
       } else if (wordHtml) {
         renderWordHtmlDocument(panel, wordHtml);
+      } else if (wordXml) {
+        renderWord2003XmlDocument(panel, wordXml);
       } else if (packageFormat === "docx" && !fileIsDocx(extension)) {
         disposeDocxFit = await renderDocx(panel, arrayBuffer, ctx.options.fit);
       } else if (packageFormat === "xlsx" && !sheetExtensions.has(extension)) {
@@ -254,7 +258,7 @@ export function officePlugin(options: OfficePluginOptions = {}): PreviewPlugin {
             delegatedInstance?.goToPage?.(page) ||
             goToRenderedPage(
               panel,
-              ".ofv-docx-page-frame, .ofv-docx-textbox-page, .ofv-msdoc-page, .ofv-slide, .ofv-ppt-binary-slide",
+              ".ofv-docx-page-frame, .ofv-docx-textbox-page, .ofv-wordml-page, .ofv-msdoc-page, .ofv-slide, .ofv-ppt-binary-slide",
               page,
               panel
             )
@@ -410,7 +414,7 @@ function createOfficeZoomController(
 } | undefined {
   const canZoom = Boolean(
     panel.querySelector(
-      ".ofv-docx-document, .ofv-sheet, .ofv-pptx-viewer > div, .ofv-ppt-binary-slide, .ofv-document, .ofv-text-block, .ofv-slide, .ofv-msdoc-document"
+      ".ofv-docx-document, .ofv-sheet, .ofv-pptx-viewer > div, .ofv-ppt-binary-slide, .ofv-document, .ofv-text-block, .ofv-slide, .ofv-wordml-document, .ofv-msdoc-document"
     )
   );
   if (!canZoom) {
@@ -4852,6 +4856,13 @@ function chartStringValues(element: Element): string[] {
     values[index] = value;
   }
   return values;
+}
+
+function detectWord2003XmlDocument(extension: string, arrayBuffer: ArrayBuffer) {
+  if ((extension !== "doc" && extension !== "dot") || hasOleSignature(arrayBuffer)) {
+    return undefined;
+  }
+  return parseWord2003XmlDocument(decodeTextBuffer(arrayBuffer));
 }
 
 type SheetViewport = {

--- a/packages/core/src/plugins/wordml.ts
+++ b/packages/core/src/plugins/wordml.ts
@@ -1,0 +1,537 @@
+const WORDML_NS = "http://schemas.microsoft.com/office/word/2003/wordml";
+
+type WordMlRunStyle = {
+  fontFamily?: string;
+  fontSizePt?: number;
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  color?: string;
+  backgroundColor?: string;
+};
+
+type WordMlParagraphStyle = {
+  alignment?: "left" | "center" | "right" | "justify";
+  marginTopPt?: number;
+  marginRightPt?: number;
+  marginBottomPt?: number;
+  marginLeftPt?: number;
+  textIndentPt?: number;
+  lineHeight?: string;
+};
+
+type WordMlRun = {
+  text: string;
+  style: WordMlRunStyle;
+};
+
+type WordMlParagraph = {
+  type: "paragraph";
+  runs: WordMlRun[];
+  style: WordMlParagraphStyle;
+  breakBefore: boolean;
+  breakAfter: boolean;
+};
+
+type WordMlTableCell = {
+  paragraphs: WordMlParagraph[];
+  colSpan: number;
+  widthPt?: number;
+  verticalAlign?: string;
+  backgroundColor?: string;
+};
+
+type WordMlTable = {
+  type: "table";
+  rows: WordMlTableCell[][];
+  columns: number[];
+  widthPt?: number;
+};
+
+type WordMlBlock = WordMlParagraph | WordMlTable | { type: "pageBreak" };
+
+type WordMlPageLayout = {
+  widthPt: number;
+  heightPt: number;
+  marginTopPt: number;
+  marginRightPt: number;
+  marginBottomPt: number;
+  marginLeftPt: number;
+  footerDistancePt: number;
+};
+
+type WordMlNamedStyle = {
+  basedOn?: string;
+  paragraph: WordMlParagraphStyle;
+  run: WordMlRunStyle;
+};
+
+export type Word2003XmlDocument = {
+  blocks: WordMlBlock[];
+  layout: WordMlPageLayout;
+  footerTemplate?: string;
+};
+
+export function parseWord2003XmlDocument(source: string): Word2003XmlDocument | undefined {
+  const normalized = source.replace(/^\uFEFF/, "");
+  if (!/<(?:\w+:)?wordDocument\b/i.test(normalized) || !normalized.includes(WORDML_NS)) {
+    return undefined;
+  }
+
+  const xml = new DOMParser().parseFromString(normalized, "application/xml");
+  if (xml.querySelector("parsererror") || xml.documentElement.localName !== "wordDocument") {
+    return undefined;
+  }
+
+  const body = descendants(xml.documentElement, "body")[0];
+  if (!body) {
+    return undefined;
+  }
+
+  const styles = parseNamedStyles(xml);
+  const blocks: WordMlBlock[] = [];
+  for (const child of collectBodyChildren(body)) {
+    if (isWordElement(child, "p")) {
+      const paragraph = parseParagraph(child, styles);
+      if (paragraph.breakBefore) blocks.push({ type: "pageBreak" });
+      blocks.push(paragraph);
+      if (paragraph.breakAfter) blocks.push({ type: "pageBreak" });
+    } else if (isWordElement(child, "tbl")) {
+      blocks.push(parseTable(child, styles));
+    }
+  }
+
+  const sectionProperties = [...descendants(body, "sectPr")].at(-1);
+  return {
+    blocks,
+    layout: parsePageLayout(sectionProperties),
+    footerTemplate: sectionProperties ? parseFooterTemplate(sectionProperties) : undefined
+  };
+}
+
+export function renderWord2003XmlDocument(panel: HTMLElement, wordDocument: Word2003XmlDocument): void {
+  panel.replaceChildren();
+  panel.classList.add("ofv-office-wordml");
+  const article = document.createElement("article");
+  article.className = "ofv-wordml-document";
+  const pages = paginateBlocks(wordDocument.blocks);
+
+  for (const [pageIndex, blocks] of pages.entries()) {
+    const page = document.createElement("section");
+    page.className = "ofv-wordml-page";
+    page.setAttribute("aria-label", `Word 2003 XML 第 ${pageIndex + 1} 页`);
+    applyPageLayout(page, wordDocument.layout);
+
+    const content = document.createElement("div");
+    content.className = "ofv-wordml-page-content";
+    for (const block of blocks) {
+      content.append(block.type === "paragraph" ? renderParagraph(block) : renderTable(block));
+    }
+    page.append(content);
+
+    if (wordDocument.footerTemplate) {
+      const footer = document.createElement("footer");
+      footer.className = "ofv-wordml-footer";
+      footer.style.bottom = scaledPt(Math.max(6, wordDocument.layout.footerDistancePt - 12));
+      footer.style.left = scaledPt(wordDocument.layout.marginLeftPt);
+      footer.style.right = scaledPt(wordDocument.layout.marginRightPt);
+      footer.textContent = wordDocument.footerTemplate
+        .replaceAll("{PAGE}", String(pageIndex + 1))
+        .replaceAll("{NUMPAGES}", String(pages.length));
+      page.append(footer);
+    }
+    article.append(page);
+  }
+  panel.append(article);
+}
+
+function collectBodyChildren(body: Element): Element[] {
+  const output: Element[] = [];
+  for (const child of elementChildren(body)) {
+    if (isWordElement(child, "p") || isWordElement(child, "tbl")) {
+      output.push(child);
+      continue;
+    }
+    if (child.localName === "sect") {
+      output.push(...elementChildren(child).filter((element) => isWordElement(element, "p") || isWordElement(element, "tbl")));
+    }
+  }
+  return output;
+}
+
+function parseNamedStyles(xml: XMLDocument): Map<string, WordMlNamedStyle> {
+  const raw = new Map<string, WordMlNamedStyle>();
+  for (const style of descendants(xml.documentElement, "style")) {
+    if (style.namespaceURI !== WORDML_NS) continue;
+    const id = wordAttribute(style, "styleId");
+    if (!id) continue;
+    const paragraphProperties = directWordChild(style, "pPr");
+    raw.set(id, {
+      basedOn: wordAttribute(directWordChild(style, "basedOn"), "val"),
+      paragraph: parseParagraphProperties(paragraphProperties),
+      run: parseRunProperties(directWordChild(style, "rPr"))
+    });
+  }
+
+  const resolved = new Map<string, WordMlNamedStyle>();
+  const resolve = (id: string, seen = new Set<string>()): WordMlNamedStyle | undefined => {
+    if (resolved.has(id)) return resolved.get(id);
+    const own = raw.get(id);
+    if (!own || seen.has(id)) return own;
+    seen.add(id);
+    const base = own.basedOn ? resolve(own.basedOn, seen) : undefined;
+    const value = {
+      basedOn: own.basedOn,
+      paragraph: { ...(base?.paragraph || {}), ...own.paragraph },
+      run: { ...(base?.run || {}), ...own.run }
+    };
+    resolved.set(id, value);
+    return value;
+  };
+  for (const id of raw.keys()) resolve(id);
+  return resolved;
+}
+
+function parseParagraph(element: Element, styles: Map<string, WordMlNamedStyle>): WordMlParagraph {
+  const paragraphProperties = directWordChild(element, "pPr");
+  const styleId = wordAttribute(directWordChild(paragraphProperties, "pStyle"), "val");
+  const namedStyle = styleId ? styles.get(styleId) : undefined;
+  const paragraphRunStyle = parseRunProperties(directWordChild(paragraphProperties, "rPr"));
+  const runs: WordMlRun[] = [];
+
+  const appendRuns = (container: Element) => {
+    for (const child of elementChildren(container)) {
+      if (isWordElement(child, "r")) {
+        const runStyle = {
+          ...(namedStyle?.run || {}),
+          ...paragraphRunStyle,
+          ...parseRunProperties(directWordChild(child, "rPr"))
+        };
+        const text = readRunText(child);
+        if (text) runs.push({ text, style: runStyle });
+      } else if (child.namespaceURI === WORDML_NS && ["hlink", "smartTag", "proofErr"].includes(child.localName)) {
+        appendRuns(child);
+      }
+    }
+  };
+  appendRuns(element);
+
+  const pageBreakBefore = directWordChild(paragraphProperties, "pageBreakBefore");
+  const hasRunPageBreak = descendants(element, "br").some(
+    (br) => br.namespaceURI === WORDML_NS && wordAttribute(br, "type") === "page"
+  );
+  return {
+    type: "paragraph",
+    runs,
+    style: { ...(namedStyle?.paragraph || {}), ...parseParagraphProperties(paragraphProperties) },
+    breakBefore: Boolean(pageBreakBefore && wordBoolean(pageBreakBefore)),
+    breakAfter: hasRunPageBreak
+  };
+}
+
+function parseTable(element: Element, styles: Map<string, WordMlNamedStyle>): WordMlTable {
+  const tableProperties = directWordChild(element, "tblPr");
+  const tableWidth = directWordChild(tableProperties, "tblW");
+  const grid = directWordChild(element, "tblGrid");
+  const columns = grid
+    ? elementChildren(grid)
+        .filter((child) => isWordElement(child, "gridCol"))
+        .map((column) => twipsToPt(wordNumber(column, "w")))
+        .filter((width) => width > 0)
+    : [];
+  const rows = elementChildren(element)
+    .filter((child) => isWordElement(child, "tr"))
+    .map((row) =>
+      elementChildren(row)
+        .filter((child) => isWordElement(child, "tc"))
+        .map((cell) => parseTableCell(cell, styles))
+    );
+  return {
+    type: "table",
+    rows,
+    columns,
+    widthPt: wordAttribute(tableWidth, "type") === "dxa" ? twipsToPt(wordNumber(tableWidth, "w")) : undefined
+  };
+}
+
+function parseTableCell(element: Element, styles: Map<string, WordMlNamedStyle>): WordMlTableCell {
+  const properties = directWordChild(element, "tcPr");
+  const width = directWordChild(properties, "tcW");
+  const shading = directWordChild(properties, "shd");
+  const paragraphs = elementChildren(element)
+    .filter((child) => isWordElement(child, "p"))
+    .map((paragraph) => parseParagraph(paragraph, styles));
+  return {
+    paragraphs,
+    colSpan: Math.max(1, wordNumber(directWordChild(properties, "gridSpan"), "val") || 1),
+    widthPt: wordAttribute(width, "type") === "dxa" ? twipsToPt(wordNumber(width, "w")) : undefined,
+    verticalAlign: wordAttribute(directWordChild(properties, "vAlign"), "val"),
+    backgroundColor: normalizeColor(wordAttribute(shading, "fill"))
+  };
+}
+
+function parseParagraphProperties(properties?: Element): WordMlParagraphStyle {
+  if (!properties) return {};
+  const alignment = wordAttribute(directWordChild(properties, "jc"), "val");
+  const spacing = directWordChild(properties, "spacing");
+  const indentation = directWordChild(properties, "ind");
+  const hanging = wordNumber(indentation, "hanging");
+  const firstLine = wordNumber(indentation, "first-line") || wordNumber(indentation, "firstLine");
+  const line = wordNumber(spacing, "line");
+  const lineRule = wordAttribute(spacing, "line-rule") || wordAttribute(spacing, "lineRule");
+  return compactObject({
+    alignment:
+      alignment === "center" || alignment === "right" || alignment === "left"
+        ? alignment
+        : alignment === "both" || alignment === "distribute"
+          ? "justify"
+          : undefined,
+    marginTopPt: optionalTwipsToPt(wordAttribute(spacing, "before")),
+    marginRightPt: optionalTwipsToPt(wordAttribute(indentation, "right")),
+    marginBottomPt: optionalTwipsToPt(wordAttribute(spacing, "after")),
+    marginLeftPt: optionalTwipsToPt(wordAttribute(indentation, "left")),
+    textIndentPt: firstLine ? twipsToPt(firstLine) : hanging ? -twipsToPt(hanging) : undefined,
+    lineHeight: line > 0 ? (lineRule === "exact" || lineRule === "at-least" ? `${twipsToPt(line)}pt` : String(line / 240)) : undefined
+  });
+}
+
+function parseRunProperties(properties?: Element): WordMlRunStyle {
+  if (!properties) return {};
+  const fonts = directWordChild(properties, "rFonts");
+  const size = wordNumber(directWordChild(properties, "sz"), "val");
+  const underline = directWordChild(properties, "u");
+  const color = wordAttribute(directWordChild(properties, "color"), "val");
+  const highlight = wordAttribute(directWordChild(properties, "highlight"), "val");
+  const bold = directWordChild(properties, "b");
+  const italic = directWordChild(properties, "i");
+  return compactObject({
+    fontFamily:
+      wordAttribute(fonts, "fareast") || wordAttribute(fonts, "ascii") || wordAttribute(fonts, "h-ansi") || wordAttribute(fonts, "hAnsi"),
+    fontSizePt: size > 0 ? size / 2 : undefined,
+    bold: bold ? wordBoolean(bold) : undefined,
+    italic: italic ? wordBoolean(italic) : undefined,
+    underline: underline ? !["none", "off", "0"].includes((wordAttribute(underline, "val") || "single").toLowerCase()) : undefined,
+    color: normalizeColor(color),
+    backgroundColor: normalizeHighlight(highlight)
+  });
+}
+
+function readRunText(run: Element): string {
+  let text = "";
+  for (const child of elementChildren(run)) {
+    if (isWordElement(child, "t")) text += child.textContent || "";
+    else if (isWordElement(child, "tab")) text += "\t";
+    else if (isWordElement(child, "br") && wordAttribute(child, "type") !== "page") text += "\n";
+  }
+  return text;
+}
+
+function parsePageLayout(sectionProperties?: Element): WordMlPageLayout {
+  const pageSize = directWordChild(sectionProperties, "pgSz");
+  const margins = directWordChild(sectionProperties, "pgMar");
+  return {
+    widthPt: twipsToPt(wordNumber(pageSize, "w") || 11906),
+    heightPt: twipsToPt(wordNumber(pageSize, "h") || 16838),
+    marginTopPt: twipsToPt(wordNumber(margins, "top") || 1440),
+    marginRightPt: twipsToPt(wordNumber(margins, "right") || 1440),
+    marginBottomPt: twipsToPt(wordNumber(margins, "bottom") || 1440),
+    marginLeftPt: twipsToPt(wordNumber(margins, "left") || 1440),
+    footerDistancePt: twipsToPt(wordNumber(margins, "footer") || 720)
+  };
+}
+
+function parseFooterTemplate(sectionProperties: Element): string | undefined {
+  const footer = descendants(sectionProperties, "ftr").find((element) => element.namespaceURI === WORDML_NS);
+  if (!footer) return undefined;
+  const paragraphs = descendants(footer, "p")
+    .filter((element) => element.namespaceURI === WORDML_NS)
+    .map(readFieldAwareText)
+    .map((value) => value.trim())
+    .filter(Boolean);
+  return paragraphs.at(-1);
+}
+
+function readFieldAwareText(paragraph: Element): string {
+  type Field = { instruction: string; separated: boolean; recognized: boolean };
+  const fields: Field[] = [];
+  let output = "";
+  const walk = (node: Node) => {
+    if (!(node instanceof Element)) {
+      for (const child of node.childNodes) walk(child);
+      return;
+    }
+    if (isWordElement(node, "fldChar")) {
+      const type = wordAttribute(node, "fldCharType");
+      if (type === "begin") fields.push({ instruction: "", separated: false, recognized: false });
+      else if (type === "separate" && fields.length > 0) {
+        const field = fields.at(-1)!;
+        field.separated = true;
+        const name = field.instruction.trim().split(/\s+/)[0]?.toUpperCase();
+        field.recognized = name === "PAGE" || name === "NUMPAGES";
+        if (field.recognized) output += `{${name}}`;
+      } else if (type === "end") fields.pop();
+      return;
+    }
+    if (isWordElement(node, "instrText")) {
+      if (fields.length > 0) fields.at(-1)!.instruction += node.textContent || "";
+      return;
+    }
+    if (isWordElement(node, "t")) {
+      const field = fields.at(-1);
+      if (!field || (field.separated && !field.recognized)) output += node.textContent || "";
+      return;
+    }
+    if (isWordElement(node, "tab")) output += "\t";
+    else if (isWordElement(node, "br")) output += "\n";
+    for (const child of node.childNodes) walk(child);
+  };
+  walk(paragraph);
+  return output;
+}
+
+function paginateBlocks(blocks: WordMlBlock[]): Exclude<WordMlBlock, { type: "pageBreak" }>[][] {
+  const pages: Exclude<WordMlBlock, { type: "pageBreak" }>[][] = [];
+  let current: Exclude<WordMlBlock, { type: "pageBreak" }>[] = [];
+  for (const block of blocks) {
+    if (block.type === "pageBreak") {
+      pages.push(current);
+      current = [];
+    } else {
+      current.push(block);
+    }
+  }
+  if (current.length > 0 || pages.length === 0) pages.push(current);
+  return pages;
+}
+
+function renderParagraph(paragraph: WordMlParagraph): HTMLParagraphElement {
+  const element = document.createElement("p");
+  element.className = "ofv-wordml-paragraph";
+  applyParagraphStyle(element, paragraph.style);
+  for (const run of paragraph.runs) {
+    const span = document.createElement("span");
+    span.textContent = run.text;
+    applyRunStyle(span, run.style);
+    element.append(span);
+  }
+  if (paragraph.runs.length === 0) element.append(document.createElement("br"));
+  return element;
+}
+
+function renderTable(tableModel: WordMlTable): HTMLTableElement {
+  const table = document.createElement("table");
+  table.className = "ofv-wordml-table";
+  if (tableModel.widthPt) table.style.width = scaledPt(tableModel.widthPt);
+  if (tableModel.columns.length > 0) {
+    const colgroup = document.createElement("colgroup");
+    for (const width of tableModel.columns) {
+      const column = document.createElement("col");
+      column.style.width = scaledPt(width);
+      colgroup.append(column);
+    }
+    table.append(colgroup);
+  }
+  const body = table.createTBody();
+  for (const rowModel of tableModel.rows) {
+    const row = body.insertRow();
+    for (const cellModel of rowModel) {
+      const cell = row.insertCell();
+      cell.colSpan = cellModel.colSpan;
+      if (cellModel.widthPt) cell.style.width = scaledPt(cellModel.widthPt);
+      if (cellModel.verticalAlign) cell.style.verticalAlign = cellModel.verticalAlign === "center" ? "middle" : cellModel.verticalAlign;
+      if (cellModel.backgroundColor) cell.style.backgroundColor = cellModel.backgroundColor;
+      for (const paragraph of cellModel.paragraphs) cell.append(renderParagraph(paragraph));
+    }
+  }
+  return table;
+}
+
+function applyPageLayout(page: HTMLElement, layout: WordMlPageLayout): void {
+  page.style.width = scaledPt(layout.widthPt);
+  page.style.height = scaledPt(layout.heightPt);
+  page.style.padding = [layout.marginTopPt, layout.marginRightPt, layout.marginBottomPt, layout.marginLeftPt].map(scaledPt).join(" ");
+}
+
+function applyParagraphStyle(element: HTMLElement, style: WordMlParagraphStyle): void {
+  if (style.alignment) element.style.textAlign = style.alignment;
+  if (style.marginTopPt !== undefined) element.style.marginTop = scaledPt(style.marginTopPt);
+  if (style.marginRightPt !== undefined) element.style.marginRight = scaledPt(style.marginRightPt);
+  if (style.marginBottomPt !== undefined) element.style.marginBottom = scaledPt(style.marginBottomPt);
+  if (style.marginLeftPt !== undefined) element.style.marginLeft = scaledPt(style.marginLeftPt);
+  if (style.textIndentPt !== undefined) element.style.textIndent = scaledPt(style.textIndentPt);
+  if (style.lineHeight) element.style.lineHeight = style.lineHeight.includes("pt") ? `calc(${style.lineHeight} * var(--ofv-office-zoom, 1))` : style.lineHeight;
+}
+
+function applyRunStyle(element: HTMLElement, style: WordMlRunStyle): void {
+  if (style.fontFamily) element.style.fontFamily = `"${style.fontFamily.replaceAll('"', '\\"')}"`;
+  if (style.fontSizePt) element.style.fontSize = scaledPt(style.fontSizePt);
+  if (style.bold !== undefined) element.style.fontWeight = style.bold ? "700" : "400";
+  if (style.italic !== undefined) element.style.fontStyle = style.italic ? "italic" : "normal";
+  if (style.underline !== undefined) element.style.textDecoration = style.underline ? "underline" : "none";
+  if (style.color) element.style.color = style.color;
+  if (style.backgroundColor) element.style.backgroundColor = style.backgroundColor;
+}
+
+function directWordChild(parent: Element | undefined, localName: string): Element | undefined {
+  return parent ? elementChildren(parent).find((child) => isWordElement(child, localName)) : undefined;
+}
+
+function descendants(parent: Element, localName: string): Element[] {
+  return Array.from(parent.getElementsByTagNameNS("*", localName));
+}
+
+function elementChildren(parent: Element): Element[] {
+  return Array.from(parent.children);
+}
+
+function isWordElement(element: Element, localName: string): boolean {
+  return element.namespaceURI === WORDML_NS && element.localName === localName;
+}
+
+function wordAttribute(element: Element | undefined, name: string): string | undefined {
+  if (!element) return undefined;
+  return element.getAttributeNS(WORDML_NS, name) || element.getAttribute(`w:${name}`) || element.getAttribute(name) || undefined;
+}
+
+function wordNumber(element: Element | undefined, name: string): number {
+  return Number.parseFloat(wordAttribute(element, name) || "0") || 0;
+}
+
+function wordBoolean(element: Element): boolean {
+  return !["off", "false", "0", "none"].includes((wordAttribute(element, "val") || "on").toLowerCase());
+}
+
+function twipsToPt(value: number): number {
+  return value / 20;
+}
+
+function optionalTwipsToPt(value?: string): number | undefined {
+  if (value === undefined) return undefined;
+  const number = Number.parseFloat(value);
+  return Number.isFinite(number) ? twipsToPt(number) : undefined;
+}
+
+function scaledPt(value: number): string {
+  return `calc(${Number(value.toFixed(3))}pt * var(--ofv-office-zoom, 1))`;
+}
+
+function normalizeColor(value?: string): string | undefined {
+  return value && /^[0-9a-f]{6}$/i.test(value) ? `#${value}` : undefined;
+}
+
+function normalizeHighlight(value?: string): string | undefined {
+  const colors: Record<string, string> = {
+    black: "#000000",
+    blue: "#0000ff",
+    cyan: "#00ffff",
+    green: "#008000",
+    magenta: "#ff00ff",
+    red: "#ff0000",
+    yellow: "#ffff00"
+  };
+  return value ? colors[value.toLowerCase()] : undefined;
+}
+
+function compactObject<T extends Record<string, unknown>>(value: T): T {
+  return Object.fromEntries(Object.entries(value).filter(([, entry]) => entry !== undefined)) as T;
+}

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -1024,6 +1024,68 @@
   margin: 0;
 }
 
+.ofv-wordml-document {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-width: max-content;
+  padding: 24px;
+  gap: 24px;
+  overflow: auto;
+  background: var(--ofv-surface-muted);
+}
+
+.ofv-wordml-page {
+  position: relative;
+  box-sizing: border-box;
+  overflow: hidden;
+  border: 1px solid var(--ofv-border);
+  background: #fff;
+  box-shadow: 0 16px 42px rgba(15, 23, 42, 0.14);
+  color: #111827;
+  font-family: "Times New Roman", SimSun, serif;
+  font-size: calc(10.5pt * var(--ofv-office-zoom, 1));
+  line-height: 1.5;
+}
+
+.ofv-wordml-page-content {
+  min-width: 0;
+}
+
+.ofv-wordml-paragraph {
+  margin: 0;
+  min-height: 1em;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
+.ofv-wordml-table {
+  max-width: 100%;
+  margin: 0;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+
+.ofv-wordml-table td {
+  padding: calc(2px * var(--ofv-office-zoom, 1)) calc(4px * var(--ofv-office-zoom, 1));
+  border: 1px solid #111827;
+  vertical-align: top;
+}
+
+.ofv-wordml-table p {
+  margin: 0;
+}
+
+.ofv-wordml-footer {
+  position: absolute;
+  font-family: SimSun, "Songti SC", serif;
+  font-size: calc(9pt * var(--ofv-office-zoom, 1));
+  line-height: 1.4;
+  text-align: center;
+  white-space: pre-wrap;
+}
+
 .ofv-document-extra {
   white-space: pre-wrap;
   overflow-wrap: anywhere;
@@ -1478,6 +1540,137 @@
 
 .ofv-msdoc-cjk-document .ofv-msdoc-table th {
   background: #e8e8e8;
+}
+
+.ofv-msdoc-notice-document .ofv-msdoc-page {
+  padding: calc(86px * var(--ofv-office-zoom, 1)) calc(104px * var(--ofv-office-zoom, 1));
+  color: #111;
+  font-family: FangSong, STFangsong, "FangSong_GB2312", SimSun, serif;
+  font-size: calc(16pt * var(--ofv-office-zoom, 1));
+  line-height: 1.8;
+}
+
+.ofv-msdoc-notice-document .ofv-msdoc-page p {
+  margin: 0;
+  text-align: justify;
+  text-indent: 2em;
+  overflow-wrap: normal;
+  word-break: normal;
+}
+
+.ofv-msdoc-notice-document .ofv-msdoc-page .ofv-msdoc-title,
+.ofv-msdoc-notice-document .ofv-msdoc-page .ofv-msdoc-subtitle {
+  margin: 0;
+  color: #111;
+  font-family: SimHei, "Microsoft YaHei", sans-serif;
+  font-size: calc(22pt * var(--ofv-office-zoom, 1));
+  font-weight: 400;
+  line-height: 1.45;
+  text-align: center;
+  text-indent: 0;
+}
+
+.ofv-msdoc-notice-document .ofv-msdoc-page .ofv-msdoc-subtitle {
+  margin-bottom: calc(30px * var(--ofv-office-zoom, 1));
+}
+
+.ofv-msdoc-notice-document .ofv-msdoc-page .ofv-msdoc-heading,
+.ofv-msdoc-notice-document .ofv-msdoc-page .ofv-msdoc-heading-level-2 {
+  margin: 0;
+  padding: 0;
+  border: 0;
+  color: #111;
+  font-family: SimHei, "Microsoft YaHei", sans-serif;
+  font-size: calc(16pt * var(--ofv-office-zoom, 1));
+  line-height: 1.8;
+  text-align: left;
+  text-indent: 2em;
+}
+
+.ofv-msdoc-notice-document .ofv-msdoc-page .ofv-msdoc-notice-salutation,
+.ofv-msdoc-notice-document .ofv-msdoc-page .ofv-msdoc-notice-contact,
+.ofv-msdoc-notice-document .ofv-msdoc-page .ofv-msdoc-notice-attachment-first,
+.ofv-msdoc-notice-document .ofv-msdoc-page .ofv-msdoc-notice-appendix-label,
+.ofv-msdoc-notice-document .ofv-msdoc-page .ofv-msdoc-notice-signature,
+.ofv-msdoc-notice-document .ofv-msdoc-page .ofv-msdoc-notice-date {
+  text-indent: 0;
+}
+
+.ofv-msdoc-notice-document .ofv-msdoc-page .ofv-msdoc-notice-contact {
+  margin-top: calc(2px * var(--ofv-office-zoom, 1));
+}
+
+.ofv-msdoc-notice-document .ofv-msdoc-page .ofv-msdoc-notice-attachment-first {
+  margin-top: calc(52px * var(--ofv-office-zoom, 1));
+}
+
+.ofv-msdoc-notice-document .ofv-msdoc-page .ofv-msdoc-notice-attachment-item {
+  margin-left: 4em;
+  text-indent: 0;
+}
+
+.ofv-msdoc-notice-document .ofv-msdoc-page > .ofv-msdoc-notice-attachment-item:first-child {
+  margin-top: calc(44px * var(--ofv-office-zoom, 1));
+}
+
+.ofv-msdoc-notice-document .ofv-msdoc-page .ofv-msdoc-notice-signature,
+.ofv-msdoc-notice-document .ofv-msdoc-page .ofv-msdoc-notice-date {
+  padding-right: 1.5em;
+  text-align: right;
+}
+
+.ofv-msdoc-notice-document .ofv-msdoc-page .ofv-msdoc-notice-signature {
+  margin-top: calc(34px * var(--ofv-office-zoom, 1));
+}
+
+.ofv-msdoc-notice-document .ofv-msdoc-page .ofv-msdoc-notice-appendix-label {
+  margin-bottom: calc(2px * var(--ofv-office-zoom, 1));
+  font-family: SimHei, "Microsoft YaHei", sans-serif;
+}
+
+.ofv-msdoc-notice-document .ofv-msdoc-page .ofv-msdoc-notice-appendix-title {
+  margin-bottom: calc(26px * var(--ofv-office-zoom, 1));
+  font-family: SimHei, "Microsoft YaHei", sans-serif;
+  font-size: calc(20pt * var(--ofv-office-zoom, 1));
+  font-weight: 400;
+  line-height: 1.45;
+  text-align: center;
+  text-indent: 0;
+}
+
+.ofv-msdoc-notice-document .ofv-msdoc-notice-table {
+  width: 100%;
+  max-width: none;
+  margin: 0;
+  color: #111;
+  font-family: SimSun, "Songti SC", serif;
+  font-size: calc(10.5pt * var(--ofv-office-zoom, 1));
+  line-height: 1.35;
+  table-layout: fixed;
+}
+
+.ofv-msdoc-notice-document .ofv-msdoc-notice-table th,
+.ofv-msdoc-notice-document .ofv-msdoc-notice-table td {
+  padding: calc(4px * var(--ofv-office-zoom, 1)) calc(3px * var(--ofv-office-zoom, 1));
+  border-color: #111;
+  background: #fff;
+  vertical-align: middle;
+  text-align: center;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+  word-break: break-all;
+}
+
+.ofv-msdoc-notice-document .ofv-msdoc-notice-table-6 th,
+.ofv-msdoc-notice-document .ofv-msdoc-notice-table-6 td {
+  padding-top: calc(7px * var(--ofv-office-zoom, 1));
+  padding-bottom: calc(7px * var(--ofv-office-zoom, 1));
+}
+
+.ofv-msdoc-notice-document .ofv-msdoc-notice-table-7 th,
+.ofv-msdoc-notice-document .ofv-msdoc-notice-table-7 td {
+  padding-top: calc(3px * var(--ofv-office-zoom, 1));
+  padding-bottom: calc(3px * var(--ofv-office-zoom, 1));
 }
 
 .ofv-msdoc-form-table th,


### PR DESCRIPTION
## 变更说明

- 识别以 `.doc` 扩展名保存的 Word 2003 XML，按页面尺寸、边距、段落/文字样式、基础表格和动态页脚进行浏览器端渲染。
- 改进中文通知类 Word 97-2003 文档的标题、正文、附件、署名和表格布局。
- 保留连续分页符产生的空白页，并按页面容量拆分长表格，避免内容压缩或裁切。

## 关联 Issue

Fixes #113

## 验证结果

- [x] 已运行与本次变更相关的测试或检查
- [x] 已使用真实文件验证修改后的预览效果
- [x] 本次修改不包含无关变更

- `vitest run packages/core/src/plugins/office.test.ts packages/core/src/style.test.ts`：99 项通过
- `@open-file-viewer/core` ESM/CJS/类型声明构建通过
- Issue #113 的两个真实 `.doc` 附件均已验证：Word 2003 XML 可直接预览；二进制文档恢复为 7 页（含空白第 3 页和拆分后的附件表格）

## 预览成功截图

- [x] 截图来自本次变更的实际预览结果

<!-- screenshot-pending -->