### PR TITLE
fix(docx): render anchored chart placeholders

### DIFF
--- a/packages/core/src/plugins/office.test.ts
+++ b/packages/core/src/plugins/office.test.ts
@@ -882,6 +882,34 @@ describe("officePlugin", () => {
     expect(container.querySelectorAll(".ofv-docx-chart-preview .ofv-chart-gridline").length).toBeGreaterThan(0);
   });
 
+  it("renders anchored DOCX chart placeholders that fill the available line width", async () => {
+    const container = document.createElement("div");
+    document.body.append(container);
+    renderDocxAsync.mockImplementationOnce(async (_data: unknown, bodyContainer: HTMLElement) => {
+      const wrapper = document.createElement("div");
+      wrapper.className = "ofv-docx-wrapper";
+      const page = document.createElement("section");
+      page.className = "ofv-docx";
+      page.innerHTML = `<p><span><div style="display:block;position:relative;width:100%;height:235.3pt;text-align:left"></div></span></p>`;
+      wrapper.append(page);
+      bodyContainer.append(wrapper);
+    });
+
+    createViewer({
+      container,
+      file: await createDocxWithChart(),
+      fileName: "anchored-chart.docx",
+      plugins: [officePlugin()]
+    });
+
+    await waitFor(() => Boolean(container.querySelector(".ofv-docx-chart-preview .ofv-chart-svg")));
+
+    const placeholder = container.querySelector<HTMLElement>(".ofv-docx-chart-preview");
+    expect(placeholder?.style.display).toBe("block");
+    expect(placeholder?.style.width).toBe("100%");
+    expect(placeholder?.querySelectorAll(".ofv-chart-svg rect[data-index]")).toHaveLength(3);
+  });
+
   it("preserves DOCX chart axis bounds, date labels, and mixed bar-line series", async () => {
     const container = document.createElement("div");
     document.body.append(container);

--- a/packages/core/src/plugins/office.ts
+++ b/packages/core/src/plugins/office.ts
@@ -1573,7 +1573,9 @@ function isDocxChartPlaceholder(element: HTMLElement): boolean {
   const position = element.style.position;
   const width = parseCssPixelValue(element.style.width);
   const height = parseCssPixelValue(element.style.height);
-  return display === "inline-block" && position === "relative" && width >= 120 && height >= 80;
+  const isInlineChart = display === "inline-block" && width >= 120;
+  const isAnchoredChart = display === "block" && element.style.width === "100%";
+  return position === "relative" && height >= 80 && (isInlineChart || isAnchoredChart);
 }
 
 function repairDocxHeadingShapeAlignment(page: HTMLElement): void {


### PR DESCRIPTION
## Summary

- recognize block-level placeholders emitted for anchored DOCX charts
- render their chart XML instead of leaving a large blank page area
- retain the existing inline-chart behavior

## Verification

- Office plugin tests: 92 passed
- core build and declaration generation passed
- verified the reported 2-page DOCX renders one chart SVG with 12 bars and 4 category labels

Closes #114