### PR TITLE
feat(core): support Ctrl-wheel and pinch zoom

### DIFF
--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -95,6 +95,7 @@
   max-width: 100%;
   overflow-x: hidden;
   overflow-y: auto;
+  touch-action: pan-x pan-y;
   background: var(--ofv-bg);
   color: var(--ofv-text);
   scrollbar-width: thin;

--- a/packages/core/src/viewer.test.ts
+++ b/packages/core/src/viewer.test.ts
@@ -255,6 +255,97 @@ describe("createViewer", () => {
     viewer.destroy();
   });
 
+  it("dispatches Ctrl or Command wheel gestures through the active preview zoom commands", async () => {
+    const container = document.createElement("div");
+    const command = vi.fn();
+    document.body.append(container);
+
+    const viewer = createViewer({
+      container,
+      file: new Blob(["gesture"], { type: "text/plain" }),
+      fileName: "gesture.txt",
+      plugins: [
+        {
+          name: "gesture-zoom",
+          match: () => true,
+          render(ctx) {
+            ctx.viewport.append(document.createElement("div"));
+            return {
+              canCommand: (nextCommand) => nextCommand === "zoom-in" || nextCommand === "zoom-out",
+              command,
+              destroy: vi.fn()
+            };
+          }
+        }
+      ]
+    });
+
+    await waitFor(() => Boolean(container.querySelector(".ofv-viewport > div")));
+    const viewport = container.querySelector<HTMLElement>(".ofv-viewport")!;
+    const ordinaryWheel = new WheelEvent("wheel", { deltaY: -100, bubbles: true, cancelable: true });
+    viewport.dispatchEvent(ordinaryWheel);
+    expect(ordinaryWheel.defaultPrevented).toBe(false);
+    expect(command).not.toHaveBeenCalled();
+
+    const zoomIn = new WheelEvent("wheel", { deltaY: -100, ctrlKey: true, bubbles: true, cancelable: true });
+    viewport.dispatchEvent(zoomIn);
+    const zoomOut = new WheelEvent("wheel", { deltaY: 100, metaKey: true, bubbles: true, cancelable: true });
+    viewport.dispatchEvent(zoomOut);
+    expect(zoomIn.defaultPrevented).toBe(true);
+    expect(zoomOut.defaultPrevented).toBe(true);
+    expect(command.mock.calls.map(([nextCommand]) => nextCommand)).toEqual(["zoom-in", "zoom-out"]);
+
+    const handledByPreview = new WheelEvent("wheel", { deltaY: -100, ctrlKey: true, bubbles: true, cancelable: true });
+    viewport.firstElementChild?.addEventListener("wheel", (event) => event.preventDefault(), { once: true });
+    viewport.firstElementChild?.dispatchEvent(handledByPreview);
+    expect(command).toHaveBeenCalledTimes(2);
+
+    viewer.destroy();
+    viewport.dispatchEvent(new WheelEvent("wheel", { deltaY: -100, ctrlKey: true, bubbles: true, cancelable: true }));
+    expect(command).toHaveBeenCalledTimes(2);
+  });
+
+  it("dispatches two-finger pinch gestures without requiring the toolbar", async () => {
+    const container = document.createElement("div");
+    const command = vi.fn();
+    document.body.append(container);
+
+    const viewer = createViewer({
+      container,
+      file: new Blob(["pinch"], { type: "text/plain" }),
+      fileName: "pinch.txt",
+      plugins: [
+        {
+          name: "pinch-zoom",
+          match: () => true,
+          render(ctx) {
+            ctx.viewport.textContent = "ready";
+            return {
+              canCommand: (nextCommand) => nextCommand === "zoom-in" || nextCommand === "zoom-out",
+              command,
+              destroy: vi.fn()
+            };
+          }
+        }
+      ]
+    });
+
+    await waitFor(() => container.querySelector(".ofv-viewport")?.textContent === "ready");
+    const viewport = container.querySelector<HTMLElement>(".ofv-viewport")!;
+    viewport.dispatchEvent(createTouchEvent("touchstart", [[0, 0], [100, 0]]));
+    const pinchOut = createTouchEvent("touchmove", [[0, 0], [112, 0]]);
+    viewport.dispatchEvent(pinchOut);
+    const pinchIn = createTouchEvent("touchmove", [[0, 0], [90, 0]]);
+    viewport.dispatchEvent(pinchIn);
+
+    expect(pinchOut.defaultPrevented).toBe(true);
+    expect(pinchIn.defaultPrevented).toBe(true);
+    expect(command.mock.calls.map(([nextCommand]) => nextCommand)).toEqual(["zoom-in", "zoom-out"]);
+
+    viewport.dispatchEvent(createTouchEvent("touchend", []));
+    viewer.destroy();
+  });
+
   it("passes a normalized initial zoom to plugins", async () => {
     const container = document.createElement("div");
     document.body.append(container);
@@ -1539,6 +1630,18 @@ describe("createViewer", () => {
     expect(removeEventListener).toHaveBeenCalledWith("fullscreenchange", expect.any(Function));
   });
 });
+
+function createTouchEvent(type: string, points: Array<[number, number]>): TouchEvent {
+  const values = points.map(([clientX, clientY]) => ({ clientX, clientY })) as Touch[];
+  const touches = Object.assign(values, {
+    item(index: number) {
+      return values[index] ?? null;
+    }
+  }) as unknown as TouchList;
+  const event = new Event(type, { bubbles: true, cancelable: true }) as TouchEvent;
+  Object.defineProperty(event, "touches", { value: touches });
+  return event;
+}
 
 async function waitFor(predicate: () => boolean, timeout = 1000): Promise<void> {
   const start = Date.now();

--- a/packages/core/src/viewer.ts
+++ b/packages/core/src/viewer.ts
@@ -114,6 +114,14 @@ export function createViewer(options: PreviewOptions): FileViewer {
   let destroyed = false;
   let renderToken = 0;
   let renderAbortController: AbortController | undefined;
+  const gestureZoom = installGestureZoom(
+    viewport,
+    (command) =>
+      !destroyed &&
+      Boolean(currentInstance?.command) &&
+      (currentInstance?.canCommand ? currentInstance.canCommand(command) : true),
+    (command) => currentInstance?.command?.(command)
+  );
 
   const setLoading = (loading: boolean) => {
     status.hidden = !loading;
@@ -245,6 +253,7 @@ export function createViewer(options: PreviewOptions): FileViewer {
       renderAbortController?.abort();
       renderAbortController = undefined;
       resizeObserver.destroy();
+      gestureZoom.destroy();
       destroyPreviewInstance(currentInstance);
       toolbar?.destroy();
       theme.destroy();
@@ -255,6 +264,99 @@ export function createViewer(options: PreviewOptions): FileViewer {
       }
     }
   };
+}
+
+function installGestureZoom(
+  viewport: HTMLElement,
+  canCommand: (command: "zoom-in" | "zoom-out") => boolean,
+  command: (command: "zoom-in" | "zoom-out") => void | boolean | undefined
+): { destroy: () => void } {
+  const wheelThreshold = 40;
+  const pinchThreshold = 1.08;
+  let accumulatedWheelDelta = 0;
+  let pinchDistance: number | undefined;
+
+  const onWheel = (event: WheelEvent) => {
+    if (event.defaultPrevented || (!event.ctrlKey && !event.metaKey) || event.deltaY === 0) {
+      return;
+    }
+    const zoomCommand = event.deltaY < 0 ? "zoom-in" : "zoom-out";
+    if (!canCommand(zoomCommand)) {
+      accumulatedWheelDelta = 0;
+      return;
+    }
+    if (event.cancelable) {
+      event.preventDefault();
+    }
+    const delta = event.deltaY * (event.deltaMode === 0 ? 1 : wheelThreshold);
+    if (accumulatedWheelDelta !== 0 && Math.sign(accumulatedWheelDelta) !== Math.sign(delta)) {
+      accumulatedWheelDelta = 0;
+    }
+    accumulatedWheelDelta += delta;
+    if (Math.abs(accumulatedWheelDelta) < wheelThreshold) {
+      return;
+    }
+    command(zoomCommand);
+    accumulatedWheelDelta = 0;
+  };
+
+  const onTouchStart = (event: TouchEvent) => {
+    pinchDistance = event.touches.length === 2 ? touchDistance(event.touches) : undefined;
+  };
+
+  const onTouchMove = (event: TouchEvent) => {
+    if (event.defaultPrevented || event.touches.length !== 2) {
+      pinchDistance = undefined;
+      return;
+    }
+    const nextDistance = touchDistance(event.touches);
+    if (!(nextDistance > 0)) {
+      return;
+    }
+    if (!(pinchDistance && pinchDistance > 0)) {
+      pinchDistance = nextDistance;
+      return;
+    }
+    const zoomCommand = nextDistance > pinchDistance ? "zoom-in" : "zoom-out";
+    if (!canCommand(zoomCommand)) {
+      return;
+    }
+    if (event.cancelable) {
+      event.preventDefault();
+    }
+    const ratio = nextDistance / pinchDistance;
+    if (ratio < pinchThreshold && ratio > 1 / pinchThreshold) {
+      return;
+    }
+    command(zoomCommand);
+    pinchDistance = nextDistance;
+  };
+
+  const onTouchEnd = (event: TouchEvent) => {
+    pinchDistance = event.touches.length === 2 ? touchDistance(event.touches) : undefined;
+  };
+
+  viewport.addEventListener("wheel", onWheel, { passive: false });
+  viewport.addEventListener("touchstart", onTouchStart, { passive: true });
+  viewport.addEventListener("touchmove", onTouchMove, { passive: false });
+  viewport.addEventListener("touchend", onTouchEnd, { passive: true });
+  viewport.addEventListener("touchcancel", onTouchEnd, { passive: true });
+
+  return {
+    destroy() {
+      viewport.removeEventListener("wheel", onWheel);
+      viewport.removeEventListener("touchstart", onTouchStart);
+      viewport.removeEventListener("touchmove", onTouchMove);
+      viewport.removeEventListener("touchend", onTouchEnd);
+      viewport.removeEventListener("touchcancel", onTouchEnd);
+    }
+  };
+}
+
+function touchDistance(touches: TouchList): number {
+  const first = touches.item(0);
+  const second = touches.item(1);
+  return first && second ? Math.hypot(second.clientX - first.clientX, second.clientY - first.clientY) : 0;
 }
 
 function parseClassNameTokens(className: string | undefined): string[] {


### PR DESCRIPTION
## Summary
- add viewport-level Ctrl/Command + wheel zoom for zoom-capable previews
- add two-finger pinch zoom without requiring the toolbar
- preserve ordinary scrolling and skip gestures already handled by a preview plugin
- remove gesture listeners when the viewer is destroyed

## Verification
- `pnpm exec vitest run packages/core/src/viewer.test.ts` (38 passed)
- archive/text timeout cases rerun serially (108 passed)
- `pnpm --filter @open-file-viewer/core build`
- Chromium: regular wheel stays at 100%; Ctrl+wheel changes 100% -> 115% -> 100%
- Chromium touch emulation: pinch changes 100% -> 115% -> 100%
- 390px mobile viewport: no horizontal overflow or console errors

## Existing baseline failures
- full suite: 1890 passed; four unrelated concurrency timeouts passed when rerun serially; `optional-peer-build.test.ts` retains its existing Windows drive-path mismatch
- workspace typecheck retains two existing missing-argument errors in `packages/core/src/plugins/office.test.ts`

Closes #119