### PR TITLE
docs(core): document download and print visibility controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -542,6 +542,28 @@ createViewer(options: PreviewOptions): FileViewer;
 
 `toolbar: true` enables the default toolbar, including multi-file navigation, zoom, rotate, download, fullscreen, print, and search when supported by the active plugin. You can extend it for business workflows without rewriting the whole viewer.
 
+### Hide Permission-Controlled Actions
+
+Set `download` or `print` to `false` when those actions are provided outside the viewer or gated by application permissions. When passing a toolbar options object, explicitly enable the other built-in controls you want to retain:
+
+```ts
+createViewer({
+  container: "#viewer",
+  file,
+  toolbar: {
+    zoom: true,
+    rotate: true,
+    download: permissions.canDownload,
+    fullscreen: true,
+    print: permissions.canPrint,
+    search: true
+  },
+  plugins
+});
+```
+
+Use `download: false` and `print: false` to remove both buttons completely. The viewer only controls their visibility; permission checks for controls rendered elsewhere remain the application's responsibility.
+
 ### Custom Labels, Order, and Icons
 
 ```ts

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -391,6 +391,26 @@ createViewer({
   container: "#viewer",
   file,
   toolbar: {
+    zoom: true,
+    rotate: true,
+    download: false,
+    fullscreen: true,
+    print: false,
+    search: true
+  },
+  plugins
+});
+```
+
+Setting `download` or `print` to `false` removes that built-in button from the DOM, so an application can render its own permission-controlled actions outside the viewer. When passing an options object, explicitly enable the other built-in controls you want to keep.
+
+For labels, ordering, icons, and custom business actions, use the same toolbar options object:
+
+```ts
+createViewer({
+  container: "#viewer",
+  file,
+  toolbar: {
     labels: {
       download: "Download",
       fullscreen: "Fullscreen",


### PR DESCRIPTION
## Summary
- document how to hide the built-in download and print buttons
- show permission-driven visibility while retaining the other standard toolbar controls
- clarify that external controls remain responsible for application permission checks

## Verification
- confirmed the existing toolbar implementation omits download when `download: false`
- confirmed the existing toolbar implementation omits print when `print: false`
- `git diff --check`

Closes #116
Closes #117