### PR TITLE
fix(office): match Word table pagination

### DIFF
--- a/packages/core/src/plugins/office.test.ts
+++ b/packages/core/src/plugins/office.test.ts
@@ -1234,6 +1234,167 @@ describe("officePlugin", () => {
     expect(scaled?.style.transformOrigin).toBe("left center");
   });
 
+  it("maps positive and negative DOCX character spacing to rendered runs in order", async () => {
+    renderDocxAsync.mockImplementationOnce(async (_data: unknown, bodyContainer: HTMLElement) => {
+      const wrapper = document.createElement("div");
+      wrapper.className = "ofv-docx-wrapper";
+      const page = document.createElement("section");
+      page.className = "ofv-docx";
+      const article = document.createElement("article");
+      for (let paragraphIndex = 0; paragraphIndex < 2; paragraphIndex += 1) {
+        const paragraph = document.createElement("p");
+        for (const text of ["AB", "CD"]) {
+          const run = document.createElement("span");
+          run.textContent = text;
+          paragraph.append(run);
+        }
+        article.append(paragraph);
+      }
+      page.append(article);
+      wrapper.append(page);
+      bodyContainer.append(wrapper);
+    });
+    const zip = new JSZip();
+    zip.file(
+      "word/document.xml",
+      `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>
+        <w:p><w:pPr><w:spacing w:line="300" w:lineRule="auto"/></w:pPr>
+          <w:r><w:rPr><w:spacing w:val="20"/></w:rPr><w:t>AB</w:t></w:r>
+          <w:r><w:rPr><w:spacing w:val="-10"/></w:rPr><w:t>CD</w:t></w:r>
+        </w:p>
+        <w:p><w:pPr><w:spacing w:line="360" w:lineRule="auto"/></w:pPr>
+          <w:r><w:rPr><w:spacing w:val="5"/></w:rPr><w:t>AB</w:t></w:r>
+          <w:r><w:t>CD</w:t></w:r>
+        </w:p>
+      </w:body></w:document>`
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    createViewer({
+      container,
+      file: await zip.generateAsync({
+        type: "blob",
+        mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+      }),
+      fileName: "character-spacing.docx",
+      plugins: [officePlugin()]
+    });
+
+    await waitFor(() => container.querySelectorAll("[data-ofv-docx-auto-line-height='true']").length === 2);
+
+    const paragraphs = Array.from(container.querySelectorAll<HTMLParagraphElement>("section.ofv-docx article p"));
+    const firstRuns = paragraphs[0]?.querySelectorAll<HTMLElement>(":scope > span");
+    const secondRuns = paragraphs[1]?.querySelectorAll<HTMLElement>(":scope > span");
+    expect(firstRuns?.[0]?.style.letterSpacing).toBe("1pt");
+    expect(firstRuns?.[1]?.style.letterSpacing).toBe("-0.5pt");
+    expect(secondRuns?.[0]?.style.letterSpacing).toBe("0.25pt");
+    expect(secondRuns?.[1]?.style.letterSpacing).toBe("");
+    expect(paragraphs[0]?.style.lineHeight).toBe("1.6375");
+    expect(paragraphs[1]?.style.lineHeight).toBe("1.965");
+  });
+
+  it("repaginates DOCX flow after restoring Word automatic line spacing without losing text", async () => {
+    renderDocxAsync.mockImplementationOnce(async (_data: unknown, bodyContainer: HTMLElement) => {
+      const wrapper = document.createElement("div");
+      wrapper.className = "ofv-docx-wrapper";
+      const page = document.createElement("section");
+      page.className = "ofv-docx";
+      page.style.width = "600px";
+      page.style.height = "100px";
+      page.style.padding = "10px";
+      const article = document.createElement("article");
+      for (const text of ["First paragraph", "Second paragraph"]) {
+        const paragraph = document.createElement("p");
+        paragraph.style.lineHeight = "1.25";
+        const run = document.createElement("span");
+        run.style.fontSize = "16px";
+        run.textContent = text;
+        paragraph.append(run);
+        paragraph.getBoundingClientRect = () => {
+          const siblings = Array.from(paragraph.parentElement?.children || []) as HTMLParagraphElement[];
+          const height = Number.parseFloat(paragraph.style.lineHeight) * 30;
+          const top = siblings.slice(0, siblings.indexOf(paragraph)).reduce(
+            (sum, sibling) => sum + Number.parseFloat(sibling.style.lineHeight) * 30,
+            0
+          );
+          return { x: 10, y: top, top, right: 590, bottom: top + height, left: 10, width: 580, height, toJSON: () => ({}) };
+        };
+        article.append(paragraph);
+      }
+      page.append(article);
+      wrapper.append(page);
+      bodyContainer.append(wrapper);
+    });
+    const zip = new JSZip();
+    zip.file(
+      "word/document.xml",
+      `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>
+        <w:p><w:pPr><w:spacing w:line="300" w:lineRule="auto"/></w:pPr><w:r><w:t>First paragraph</w:t></w:r></w:p>
+        <w:p><w:pPr><w:spacing w:line="300" w:lineRule="auto"/></w:pPr><w:r><w:t>Second paragraph</w:t></w:r></w:p>
+      </w:body></w:document>`
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    createViewer({
+      container,
+      file: await zip.generateAsync({
+        type: "blob",
+        mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+      }),
+      fileName: "automatic-line-spacing.docx",
+      plugins: [officePlugin()]
+    });
+
+    await waitFor(() => container.querySelectorAll("section.ofv-docx").length === 2);
+
+    const pages = Array.from(container.querySelectorAll<HTMLElement>("section.ofv-docx"));
+    expect(pages.map((page) => page.querySelector("article")?.textContent)).toEqual(["First paragraph", "Second paragraph"]);
+    expect(pages[1]?.dataset.ofvDocxFlowContinuation).toBe("true");
+  });
+
+  it("uses Word's taller automatic line box for DOCX table-cell paragraphs", async () => {
+    renderDocxAsync.mockImplementationOnce(async (_data: unknown, bodyContainer: HTMLElement) => {
+      const wrapper = document.createElement("div");
+      wrapper.className = "ofv-docx-wrapper";
+      const page = document.createElement("section");
+      page.className = "ofv-docx";
+      const article = document.createElement("article");
+      const bodyParagraph = document.createElement("p");
+      bodyParagraph.textContent = "Body";
+      const table = document.createElement("table");
+      const cellParagraph = table.insertRow().insertCell().appendChild(document.createElement("p"));
+      cellParagraph.textContent = "Cell";
+      article.append(bodyParagraph, table);
+      page.append(article);
+      wrapper.append(page);
+      bodyContainer.append(wrapper);
+    });
+    const zip = new JSZip();
+    zip.file(
+      "word/document.xml",
+      `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>
+        <w:p><w:pPr><w:spacing w:line="300" w:lineRule="auto"/></w:pPr><w:r><w:t>Body</w:t></w:r></w:p>
+        <w:tbl><w:tr><w:tc><w:p><w:pPr><w:spacing w:line="300" w:lineRule="auto"/></w:pPr><w:r><w:t>Cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>
+      </w:body></w:document>`
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    createViewer({
+      container,
+      file: await zip.generateAsync({
+        type: "blob",
+        mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+      }),
+      fileName: "table-automatic-line-spacing.docx",
+      plugins: [officePlugin()]
+    });
+
+    await waitFor(() => container.querySelectorAll("[data-ofv-docx-auto-line-height='true']").length === 2);
+
+    expect(container.querySelector<HTMLParagraphElement>("article > p")?.style.lineHeight).toBe("1.6375");
+    expect(container.querySelector<HTMLParagraphElement>("td > p")?.style.lineHeight).toBe("2");
+  });
+
   it("aligns right-tab DOCX text to the OOXML tab position", async () => {
     renderDocxAsync.mockImplementationOnce(async (_data: unknown, bodyContainer: HTMLElement) => {
       const wrapper = document.createElement("div");
@@ -1568,7 +1729,7 @@ describe("officePlugin", () => {
     document.body.append(container);
     createViewer({
       container,
-      file: await createMinimalDocx(),
+      file: await createMinimalDocx("Cover"),
       fileName: "closing-date-empty-continuation.docx",
       plugins: [officePlugin()]
     });
@@ -1606,7 +1767,7 @@ describe("officePlugin", () => {
     document.body.append(container);
     createViewer({
       container,
-      file: await createMinimalDocx(),
+      file: await createMinimalDocx("Cover"),
       fileName: "closing-date-nonempty-continuation.docx",
       plugins: [officePlugin()]
     });
@@ -1816,6 +1977,126 @@ describe("officePlugin", () => {
     expect(continuationTable?.dataset.ofvDocxTableContinuation).toBe("true");
     expect(pages[1]?.querySelector("header")?.textContent).toBe("Repeated header");
     expect(pages[1]?.querySelectorAll("article p")).toHaveLength(0);
+  });
+
+  it("splits a DOCX table through a long rowspan without leaving an empty source page", async () => {
+    renderDocxAsync.mockImplementationOnce(async (_data: unknown, bodyContainer: HTMLElement) => {
+      const wrapper = document.createElement("div");
+      wrapper.className = "ofv-docx-wrapper";
+      const page = document.createElement("section");
+      page.className = "ofv-docx";
+      page.style.width = "600px";
+      page.style.height = "260px";
+      page.style.padding = "20px";
+      const article = document.createElement("article");
+      const leadingEmpty = document.createElement("p");
+      const table = document.createElement("table");
+      for (let index = 0; index < 5; index += 1) {
+        const row = table.insertRow();
+        const value = row.insertCell();
+        value.textContent = `Row ${index + 1}`;
+        if (index === 0) {
+          const merged = row.insertCell();
+          merged.textContent = "Merged label";
+          merged.rowSpan = 5;
+        }
+        row.getBoundingClientRect = () => {
+          const currentTable = row.closest("table")!;
+          const rowIndex = Array.from(currentTable.rows).indexOf(row);
+          const top = 40 + rowIndex * 60;
+          return { x: 20, y: top, top, right: 580, bottom: top + 60, left: 20, width: 560, height: 60, toJSON: () => ({}) };
+        };
+      }
+      table.getBoundingClientRect = () => ({
+        x: 20, y: 40, top: 40, right: 580, bottom: 340, left: 20, width: 560, height: 300, toJSON: () => ({})
+      });
+      article.append(leadingEmpty, table);
+      page.append(article);
+      wrapper.append(page);
+      bodyContainer.append(wrapper);
+    });
+
+    const container = document.createElement("div");
+    document.body.append(container);
+    createViewer({
+      container,
+      file: new Blob(["docx"], { type: "application/vnd.openxmlformats-officedocument.wordprocessingml.document" }),
+      fileName: "long-rowspan.docx",
+      plugins: [officePlugin()]
+    });
+
+    await waitFor(() => container.querySelectorAll("section.ofv-docx").length === 2);
+
+    const pages = Array.from(container.querySelectorAll<HTMLElement>("section.ofv-docx"));
+    const firstTable = pages[0]?.querySelector<HTMLTableElement>("article table");
+    const continuationTable = pages[1]?.querySelector<HTMLTableElement>("article table");
+    expect(Array.from(firstTable?.rows || []).map((row) => row.cells[0]?.textContent)).toEqual(["Row 1", "Row 2", "Row 3"]);
+    expect(Array.from(continuationTable?.rows || []).map((row) => row.cells[0]?.textContent)).toEqual(["Row 4", "Row 5"]);
+    expect(firstTable?.rows[0]?.cells[1]?.rowSpan).toBe(3);
+    expect(continuationTable?.rows[0]?.cells[1]?.rowSpan).toBe(2);
+    expect(continuationTable?.rows[0]?.cells[1]?.dataset.ofvDocxRowspanContinuation).toBe("true");
+    expect(continuationTable?.rows[0]?.cells[1]?.textContent).toBe("");
+    expect(pages[0]?.querySelector("article table")).not.toBeNull();
+  });
+
+  it("moves a closing signature group with its DOCX section break", async () => {
+    renderDocxAsync.mockImplementationOnce(async (_data: unknown, bodyContainer: HTMLElement) => {
+      const wrapper = document.createElement("div");
+      wrapper.className = "ofv-docx-wrapper";
+      const page = document.createElement("section");
+      page.className = "ofv-docx";
+      page.style.width = "600px";
+      page.style.height = "180px";
+      page.style.padding = "20px";
+      const article = document.createElement("article");
+      for (const text of ["Body", "", "First signature", "Second signature", "2 0 2 5 年 7 月 7 日", ""]) {
+        const paragraph = document.createElement("p");
+        paragraph.textContent = text;
+        article.append(paragraph);
+      }
+      vi.spyOn(HTMLElement.prototype, "getBoundingClientRect").mockImplementation(function (this: HTMLElement) {
+        if (this.tagName !== "P") {
+          return { x: 0, y: 0, top: 0, right: 600, bottom: 0, left: 0, width: 600, height: 0, toJSON: () => ({}) };
+        }
+        const siblings = Array.from(this.parentElement?.children || []);
+        const index = siblings.indexOf(this);
+        const top = index * 30;
+        return { x: 20, y: top, top, right: 580, bottom: top + 30, left: 20, width: 560, height: 30, toJSON: () => ({}) };
+      });
+      page.append(article);
+      wrapper.append(page);
+      bodyContainer.append(wrapper);
+    });
+    const zip = new JSZip();
+    zip.file(
+      "word/document.xml",
+      `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>
+        <w:p><w:r><w:t>Body</w:t></w:r></w:p><w:p/>
+        <w:p><w:r><w:t>First signature</w:t></w:r></w:p>
+        <w:p><w:r><w:t>Second signature</w:t></w:r></w:p>
+        <w:p><w:r><w:t>2 0 2 5 年 7 月 7 日</w:t></w:r></w:p>
+        <w:p><w:pPr><w:spacing w:line="300" w:lineRule="auto"/><w:sectPr/><w:rPr><w:sz w:val="24"/></w:rPr></w:pPr></w:p>
+        <w:sectPr/>
+      </w:body></w:document>`
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    createViewer({
+      container,
+      file: await zip.generateAsync({
+        type: "blob",
+        mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+      }),
+      fileName: "section-closing.docx",
+      plugins: [officePlugin()]
+    });
+
+    await waitFor(() => container.querySelectorAll("section.ofv-docx").length === 2);
+
+    const pages = Array.from(container.querySelectorAll<HTMLElement>("section.ofv-docx"));
+    expect(pages[0]?.querySelector("article")?.textContent).toBe("Body");
+    expect(pages[1]?.querySelector("article")?.textContent).toBe("First signatureSecond signature2 0 2 5 年 7 月 7 日");
+    expect(pages[1]?.querySelector("[data-ofv-docx-section-break='true']")).not.toBeNull();
   });
 
   it("keeps DOCX page width stable inside narrow containers", async () => {

--- a/packages/core/src/plugins/office.ts
+++ b/packages/core/src/plugins/office.ts
@@ -1430,6 +1430,9 @@ async function normalizeDocxLayout(container: HTMLElement, arrayBuffer: ArrayBuf
   repairDocxFloatingShapeTextboxes(container, hints.floatingShapes);
   repairDocxChartPlaceholders(container, charts);
   repairDocxComplexScriptFontSizes(container, hints.complexScriptFontSizeParagraphs);
+  repairDocxCharacterSpacing(container, hints.characterSpacingParagraphs);
+  repairDocxAutoLineHeights(container, hints.autoLineHeightParagraphs);
+  markDocxSectionBreakParagraphs(container, hints.sectionBreakParagraphIndexes);
   repairDocxCharacterScaling(container, hints.characterScaleParagraphs);
   const pages = container.querySelectorAll<HTMLElement>("section.ofv-docx");
   for (const page of pages) {
@@ -1728,6 +1731,20 @@ type DocxLayoutHints = {
     text: string;
     scalePercent: number;
   }>;
+  characterSpacingParagraphs: Array<{
+    text: string;
+    runs: Array<{
+      text: string;
+      spacingPt?: number;
+    }>;
+  }>;
+  autoLineHeightParagraphs: Array<{
+    paragraphIndex: number;
+    text: string;
+    lineMultiple: number;
+    fontSizePt?: number;
+  }>;
+  sectionBreakParagraphIndexes: number[];
   hasVerticalTextDirection: boolean;
 };
 
@@ -1757,6 +1774,9 @@ async function readDocxLayoutHints(arrayBuffer: ArrayBuffer): Promise<DocxLayout
       pageNumberFieldResults: footerXmls.flatMap(extractDocxPageNumberFieldResults),
       complexScriptFontSizeParagraphs: documentXml ? extractDocxComplexScriptFontSizeHints(documentXml) : [],
       characterScaleParagraphs: documentXml ? extractDocxCharacterScaleHints(documentXml) : [],
+      characterSpacingParagraphs: documentXml ? extractDocxCharacterSpacingHints(documentXml) : [],
+      autoLineHeightParagraphs: documentXml ? extractDocxAutoLineHeightHints(documentXml) : [],
+      sectionBreakParagraphIndexes: documentXml ? extractDocxSectionBreakParagraphIndexes(documentXml) : [],
       hasVerticalTextDirection: Boolean(documentXml && /<w:textDirection\b/.test(documentXml))
     };
   } catch {
@@ -1768,6 +1788,9 @@ async function readDocxLayoutHints(arrayBuffer: ArrayBuffer): Promise<DocxLayout
       pageNumberFieldResults: [],
       complexScriptFontSizeParagraphs: [],
       characterScaleParagraphs: [],
+      characterSpacingParagraphs: [],
+      autoLineHeightParagraphs: [],
+      sectionBreakParagraphIndexes: [],
       hasVerticalTextDirection: false
     };
   }
@@ -2019,6 +2042,214 @@ function repairDocxCharacterScaling(
     }
     paragraph.style.whiteSpace = "nowrap";
     paragraph.dataset.ofvDocxCharacterScaled = "true";
+  }
+}
+
+function extractDocxCharacterSpacingHints(xml: string): DocxLayoutHints["characterSpacingParagraphs"] {
+  const document = parseOfficeXml(xml);
+  if (!document) {
+    return [];
+  }
+  return Array.from(document.getElementsByTagName("*"))
+    .filter((element) => element.localName === "p")
+    .flatMap((paragraph) => {
+      const runs: DocxLayoutHints["characterSpacingParagraphs"][number]["runs"] = Array.from(paragraph.children)
+        .filter((element) => element.localName === "r")
+        .flatMap((run) => {
+          const text = Array.from(run.getElementsByTagName("*"))
+            .filter((element) => element.localName === "t")
+            .map((element) => element.textContent || "")
+            .join("");
+          if (!text) {
+            return [];
+          }
+          const runProperties = Array.from(run.children).find((element) => element.localName === "rPr");
+          const spacing = runProperties
+            ? Array.from(runProperties.children).find((element) => element.localName === "spacing")
+            : undefined;
+          const spacingTwentieths = Number(spacing ? getXmlAttribute(spacing, "val") : Number.NaN);
+          return Number.isFinite(spacingTwentieths)
+            ? [{ text, spacingPt: spacingTwentieths / 20 }]
+            : [{ text }];
+        });
+      const text = normalizePreviewText(runs.map((run) => run.text).join(""));
+      return text && runs.some((run) => run.spacingPt !== undefined) ? [{ text, runs }] : [];
+    });
+}
+
+function repairDocxCharacterSpacing(
+  container: HTMLElement,
+  hints: DocxLayoutHints["characterSpacingParagraphs"]
+): void {
+  if (hints.length === 0) {
+    return;
+  }
+  const candidatesByText = new Map<string, HTMLParagraphElement[]>();
+  for (const paragraph of container.querySelectorAll<HTMLParagraphElement>("section.ofv-docx article p")) {
+    const text = normalizePreviewText(paragraph.textContent || "");
+    if (!text) {
+      continue;
+    }
+    const candidates = candidatesByText.get(text) || [];
+    candidates.push(paragraph);
+    candidatesByText.set(text, candidates);
+  }
+
+  for (const hint of hints) {
+    const paragraph = candidatesByText.get(hint.text)?.shift();
+    if (!paragraph) {
+      continue;
+    }
+    const renderedRuns = getRenderedDocxRuns(paragraph);
+    let renderedIndex = 0;
+    for (const run of hint.runs) {
+      while (renderedIndex < renderedRuns.length) {
+        const renderedRun = renderedRuns[renderedIndex++]!;
+        if (!docxRunTextsMatch(renderedRun.textContent || "", run.text)) {
+          continue;
+        }
+        if (run.spacingPt !== undefined) {
+          renderedRun.style.letterSpacing = `${formatCssNumber(run.spacingPt)}pt`;
+          renderedRun.dataset.ofvDocxCharacterSpacing = "true";
+        }
+        break;
+      }
+    }
+  }
+}
+
+function getRenderedDocxRuns(paragraph: HTMLParagraphElement): HTMLElement[] {
+  return Array.from(paragraph.children).flatMap((child) => {
+    if (!(child instanceof HTMLElement)) {
+      return [];
+    }
+    if (child.tagName === "SPAN") {
+      return [child];
+    }
+    return Array.from(child.querySelectorAll<HTMLElement>(":scope > span"));
+  });
+}
+
+function docxRunTextsMatch(renderedText: string, sourceText: string): boolean {
+  const normalizedSource = normalizePreviewText(sourceText);
+  return normalizedSource
+    ? normalizePreviewText(renderedText) === normalizedSource
+    : sourceText.length > 0 && /^\s+$/.test(sourceText) && /^\s+$/.test(renderedText);
+}
+
+const DOCX_WORD_SINGLE_LINE_EM = 1.31;
+const DOCX_WORD_TABLE_SINGLE_LINE_EM = 1.6;
+
+function extractDocxAutoLineHeightHints(xml: string): DocxLayoutHints["autoLineHeightParagraphs"] {
+  const document = parseOfficeXml(xml);
+  if (!document) {
+    return [];
+  }
+  return Array.from(document.getElementsByTagName("*"))
+    .filter((element) => element.localName === "p")
+    .flatMap((paragraph, paragraphIndex): DocxLayoutHints["autoLineHeightParagraphs"] => {
+      const properties = Array.from(paragraph.children).find((element) => element.localName === "pPr");
+      const spacing = properties
+        ? Array.from(properties.children).find((element) => element.localName === "spacing")
+        : undefined;
+      const runProperties = properties
+        ? Array.from(properties.children).find((element) => element.localName === "rPr")
+        : undefined;
+      const fontSize = runProperties
+        ? Array.from(runProperties.children).find((element) => element.localName === "sz")
+        : undefined;
+      const halfPointFontSize = Number(fontSize ? getXmlAttribute(fontSize, "val") : Number.NaN);
+      const line = Number(spacing ? getXmlAttribute(spacing, "line") : 0);
+      const text = normalizePreviewText(
+        Array.from(paragraph.getElementsByTagName("*"))
+          .filter((element) => element.localName === "t")
+          .map((element) => element.textContent || "")
+          .join("")
+      );
+      if (!spacing || getXmlAttribute(spacing, "lineRule") !== "auto" || !Number.isFinite(line) || line <= 0) {
+        return [];
+      }
+      return [{
+        paragraphIndex,
+        text,
+        lineMultiple: line / 240,
+        ...(Number.isFinite(halfPointFontSize) && halfPointFontSize > 0
+          ? { fontSizePt: halfPointFontSize / 2 }
+          : {})
+      }];
+    });
+}
+
+function repairDocxAutoLineHeights(
+  container: HTMLElement,
+  hints: DocxLayoutHints["autoLineHeightParagraphs"]
+): void {
+  if (hints.length === 0) {
+    return;
+  }
+  const paragraphs = Array.from(container.querySelectorAll<HTMLParagraphElement>("section.ofv-docx article p"));
+  for (const hint of hints) {
+    const paragraph = paragraphs[hint.paragraphIndex];
+    if (!paragraph || normalizePreviewText(paragraph.textContent || "") !== hint.text) {
+      continue;
+    }
+    // OOXML's auto value is measured in 240ths of Word's font line box,
+    // while a CSS unitless line-height is measured directly against 1em.
+    // Word also gives table-cell paragraphs a taller line box than body text.
+    const singleLineEm = paragraph.closest("td, th")
+      ? DOCX_WORD_TABLE_SINGLE_LINE_EM
+      : DOCX_WORD_SINGLE_LINE_EM;
+    paragraph.style.lineHeight = formatCssNumber(hint.lineMultiple * singleLineEm);
+    if (!hint.text && hint.fontSizePt) {
+      paragraph.style.fontSize = `${formatCssNumber(hint.fontSizePt)}pt`;
+      paragraph.style.minHeight = `${formatCssNumber(hint.fontSizePt * hint.lineMultiple * singleLineEm)}pt`;
+    }
+    paragraph.dataset.ofvDocxAutoLineHeight = "true";
+  }
+}
+
+function extractDocxSectionBreakParagraphIndexes(xml: string): number[] {
+  const document = parseOfficeXml(xml);
+  if (!document) {
+    return [];
+  }
+  return Array.from(document.getElementsByTagName("*"))
+    .filter((element) => element.localName === "p")
+    .flatMap((paragraph, paragraphIndex) => {
+      const properties = Array.from(paragraph.children).find((element) => element.localName === "pPr");
+      return properties && Array.from(properties.children).some((element) => element.localName === "sectPr")
+        ? [paragraphIndex]
+        : [];
+    });
+}
+
+function markDocxSectionBreakParagraphs(container: HTMLElement, paragraphIndexes: number[]): void {
+  if (paragraphIndexes.length === 0) {
+    return;
+  }
+  const sourcePages = Array.from(
+    container.querySelectorAll<HTMLElement>(".ofv-docx-wrapper > section.ofv-docx")
+  );
+  if (sourcePages.length > paragraphIndexes.length) {
+    sourcePages.slice(0, paragraphIndexes.length).forEach((page) => {
+      const article = Array.from(page.children).find(
+        (child): child is HTMLElement => child instanceof HTMLElement && child.tagName === "ARTICLE"
+      );
+      const boundary = Array.from(article?.children || [])
+        .reverse()
+        .find((child): child is HTMLParagraphElement => child instanceof HTMLParagraphElement);
+      if (boundary) {
+        boundary.dataset.ofvDocxSectionBreak = "true";
+      }
+    });
+    return;
+  }
+  const paragraphs = Array.from(container.querySelectorAll<HTMLParagraphElement>("section.ofv-docx article p"));
+  for (const paragraphIndex of paragraphIndexes) {
+    const paragraph = paragraphs[paragraphIndex];
+    if (paragraph) {
+      paragraph.dataset.ofvDocxSectionBreak = "true";
+    }
   }
 }
 
@@ -2723,6 +2954,32 @@ function paginateDocxPage(sourcePage: HTMLElement): void {
 
     let overflowBlock = block;
     while (docxBlockExceedsPage(overflowBlock, page, nominalHeight) && continuationCount < 100) {
+      if (overflowBlock.dataset.ofvDocxSectionBreak === "true") {
+        const previous = overflowBlock.previousElementSibling;
+        if (previous instanceof HTMLElement && shouldMoveDocxParagraphWhole(previous)) {
+          const trailingBlocks = [previous, overflowBlock];
+          if (looksLikeDocxClosingDateParagraph(previous)) {
+            let sibling = previous.previousElementSibling;
+            while (
+              sibling instanceof HTMLElement &&
+              sibling.tagName === "P" &&
+              !docxBlockIsVisuallyEmpty(sibling) &&
+              trailingBlocks.length < 4
+            ) {
+              trailingBlocks.unshift(sibling);
+              sibling = sibling.previousElementSibling;
+            }
+          }
+          trailingBlocks.forEach((item) => item.remove());
+          const continuation = createDocxContinuationPage(sourcePage, flowRoot);
+          page.after(continuation.page);
+          page = continuation.page;
+          pageFlow = continuation.flowRoot;
+          pageFlow.append(...trailingBlocks);
+          continuationCount += 1;
+          break;
+        }
+      }
       if (docxBlockIsVisuallyEmpty(overflowBlock)) {
         overflowBlock.remove();
         break;
@@ -2748,6 +3005,10 @@ function paginateDocxPage(sourcePage: HTMLElement): void {
   attachDocxPageBottomFrames(page, bottomFrames);
 }
 
+function looksLikeDocxClosingDateParagraph(paragraph: HTMLElement): boolean {
+  return /2\s*0\s*\d\s*\d\s*年\s*\d{1,2}\s*月\s*\d{1,2}\s*日/.test(paragraph.textContent || "");
+}
+
 function repairDocxFirstPageClosingDate(container: HTMLElement): void {
   const pages = Array.from(container.querySelectorAll<HTMLElement>("section.ofv-docx"));
   const firstPage = pages[0];
@@ -2762,6 +3023,9 @@ function repairDocxFirstPageClosingDate(container: HTMLElement): void {
     return;
   }
   const sourcePage = dateParagraph.closest<HTMLElement>("section.ofv-docx");
+  if (sourcePage?.querySelector("[data-ofv-docx-section-break='true']")) {
+    return;
+  }
   const signatory = Array.from(firstPage.querySelectorAll<HTMLElement>("article p"))
     .filter((paragraph) => normalizePreviewText(paragraph.textContent || "") === "中共玉门市委办公室")
     .at(-1);
@@ -2857,18 +3121,27 @@ function splitDocxTableToFit(table: HTMLTableElement, page: HTMLElement, nominal
 
   const pageBottom = docxPageContentBottom(page, nominalHeight);
   let splitIndex = 0;
+  let lastFittingIndex = 0;
   for (let index = 1; index < rows.length; index += 1) {
     if (rows[index - 1]!.getBoundingClientRect().bottom > pageBottom) {
       break;
     }
+    lastFittingIndex = index;
     if (!docxTableBoundaryCrossesRowSpan(rows, index)) {
       splitIndex = index;
     }
+  }
+  if (lastFittingIndex > splitIndex && lastFittingIndex < rows.length) {
+    splitIndex = lastFittingIndex;
   }
   if (splitIndex <= 0 || splitIndex >= rows.length) {
     return undefined;
   }
 
+  const cellPlacements = mapDocxTableCellPlacements(rows);
+  const crossingCells = Array.from(cellPlacements.values()).filter(
+    (placement) => placement.rowIndex < splitIndex && placement.rowIndex + placement.rowSpan > splitIndex
+  );
   const continuation = table.cloneNode(false) as HTMLTableElement;
   continuation.dataset.ofvDocxTableContinuation = "true";
   continuation.removeAttribute("id");
@@ -2896,7 +3169,54 @@ function splitDocxTableToFit(table: HTMLTableElement, page: HTMLElement, nominal
       continuation.append(row);
     }
   }
+  const firstContinuationRow = rows[splitIndex];
+  if (firstContinuationRow) {
+    for (const placement of crossingCells.sort((left, right) => left.columnIndex - right.columnIndex)) {
+      placement.cell.rowSpan = splitIndex - placement.rowIndex;
+      const continuationCell = placement.cell.cloneNode(true) as HTMLTableCellElement;
+      continuationCell.replaceChildren();
+      continuationCell.removeAttribute("id");
+      continuationCell.querySelectorAll<HTMLElement>("[id]").forEach((element) => element.removeAttribute("id"));
+      continuationCell.rowSpan = placement.rowIndex + placement.rowSpan - splitIndex;
+      continuationCell.dataset.ofvDocxRowspanContinuation = "true";
+      const referenceCell = Array.from(firstContinuationRow.cells).find(
+        (cell) => (cellPlacements.get(cell)?.columnIndex ?? Number.POSITIVE_INFINITY) > placement.columnIndex
+      );
+      firstContinuationRow.insertBefore(continuationCell, referenceCell || null);
+    }
+  }
   return continuation;
+}
+
+type DocxTableCellPlacement = {
+  cell: HTMLTableCellElement;
+  rowIndex: number;
+  columnIndex: number;
+  rowSpan: number;
+};
+
+function mapDocxTableCellPlacements(rows: HTMLTableRowElement[]): Map<HTMLTableCellElement, DocxTableCellPlacement> {
+  const placements = new Map<HTMLTableCellElement, DocxTableCellPlacement>();
+  const occupiedUntil: number[] = [];
+  rows.forEach((row, rowIndex) => {
+    let columnIndex = 0;
+    for (const cell of Array.from(row.cells)) {
+      const rowSpan = Math.max(1, cell.rowSpan);
+      const columnSpan = Math.max(1, cell.colSpan);
+      while (
+        Array.from({ length: columnSpan }, (_, offset) => occupiedUntil[columnIndex + offset] || 0)
+          .some((occupiedRow) => occupiedRow > rowIndex)
+      ) {
+        columnIndex += 1;
+      }
+      placements.set(cell, { cell, rowIndex, columnIndex, rowSpan });
+      for (let column = columnIndex; column < columnIndex + columnSpan; column += 1) {
+        occupiedUntil[column] = Math.max(occupiedUntil[column] || 0, rowIndex + rowSpan);
+      }
+      columnIndex += columnSpan;
+    }
+  });
+  return placements;
 }
 
 function docxTableBoundaryCrossesRowSpan(rows: HTMLTableRowElement[], splitIndex: number): boolean {


### PR DESCRIPTION
## 变更说明

- 支持 DOCX 正负字符间距（`w:rPr/w:spacing`），避免正文与 Word 的横向排版逐行漂移。
- 恢复普通段落与表格单元格的 Word 自动行距，并按空段落字体高度参与分页。
- 修复跨页长 `rowspan` 表格的延续单元格，避免表格被错误整体推到下一页或产生空白页。
- 修复分节末尾签章、日期被错误拆页，并避免旧的日期定位逻辑干扰正常分节分页。

## 关联 Issue

Fixes #110

## 验证结果

- [x] 已运行与本次变更相关的测试或检查
- [x] 已使用真实文件验证修改后的预览效果
- [x] 本次修改不包含无关变更

- Office 插件测试：96 项全部通过。
- Core TypeScript 类型检查通过。
- Core ESM/CJS/类型声明构建通过。
- `git diff --check` 通过。
- 使用 Issue #110 的真实 DOCX 验证：渲染 26 页，与 Word 2024 页数一致；6034 字文本完整；无空白页。
- 第 21-24 页长表格分页与 Word 一致：第 21 页为表头及 1-9 行，第 22 页为 10-15 行，第 23 页为 16-30 行，第 24 页为 31-36 行。
- 后续表格由错误的 25/4 行分页修正为 21/8 行。

## 预览成功截图

- [x] 截图来自本次变更的实际预览结果

下图为 Issue #110 真实文档修复后的第 21 页，展示表头、1-9 行及跨页合并单元格的正确分页结果。

<img width="310" height="492" alt="Issue #110 修复后第 21 页预览" src="https://github.com/user-attachments/assets/707e14a1-2c2c-46fb-9bc2-7a532d09a36b" />
