### PR TITLE
fix(office): improve Word table layout fidelity

### DIFF
--- a/packages/core/src/plugins/msdoc.ts
+++ b/packages/core/src/plugins/msdoc.ts
@@ -1652,7 +1652,7 @@ function paginateCjkNoticeBlocks(blocks: LegacyWordBlock[]): LegacyWordBlock[][]
         continue;
       }
 
-      const rowUnits = block.rows[0]?.length === 7 ? 1.65 : 1.4;
+      const rowUnits = block.rows[0]?.length === 7 ? 1.65 : 1.35;
       let offset = 0;
       while (offset < block.rows.length) {
         let availableRows = Math.floor((maxUnits - usedUnits + 0.001) / rowUnits);

--- a/packages/core/src/plugins/office.test.ts
+++ b/packages/core/src/plugins/office.test.ts
@@ -1521,6 +1521,29 @@ describe("officePlugin", () => {
     expect(pages[1]?.dataset.ofvDocxFlowContinuation).toBe("true");
   });
 
+  it("does not paginate authored DOCX section pages a second time", async () => {
+    renderDocxAsync.mockImplementationOnce(async (_data: unknown, bodyContainer: HTMLElement) => {
+      const wrapper = document.createElement("div");
+      wrapper.className = "ofv-docx-wrapper";
+      wrapper.innerHTML = `<section class="ofv-docx" style="height:100px;padding:10px"><article><p>Page 1</p><p>Tail 1</p></article></section>
+        <section class="ofv-docx" style="height:100px;padding:10px"><article><p>Page 2</p><p>Tail 2</p></article></section>`;
+      wrapper.querySelectorAll<HTMLElement>("article p:last-child").forEach((paragraph) => {
+        paragraph.getBoundingClientRect = () => ({
+          x: 10, y: 80, top: 80, right: 590, bottom: 140, left: 10, width: 580, height: 60, toJSON: () => ({})
+        });
+      });
+      bodyContainer.append(wrapper);
+    });
+    const container = document.createElement("div");
+    document.body.append(container);
+    createViewer({ container, file: await createDocxWithAuthoredPageSections(), fileName: "sections.docx", plugins: [officePlugin()] });
+
+    await waitFor(() => container.querySelectorAll("section.ofv-docx").length === 2);
+    const pages = Array.from(container.querySelectorAll<HTMLElement>("section.ofv-docx"));
+    expect(pages.map((page) => page.querySelector("article")?.textContent)).toEqual(["Page 1Tail 1", "Page 2Tail 2"]);
+    expect(container.querySelector("[data-ofv-docx-flow-continuation]")).toBeNull();
+  });
+
   it("uses Word's taller automatic line box for DOCX table-cell paragraphs", async () => {
     renderDocxAsync.mockImplementationOnce(async (_data: unknown, bodyContainer: HTMLElement) => {
       const wrapper = document.createElement("div");
@@ -1532,7 +1555,10 @@ describe("officePlugin", () => {
       bodyParagraph.textContent = "Body";
       const table = document.createElement("table");
       const cellParagraph = table.insertRow().insertCell().appendChild(document.createElement("p"));
-      cellParagraph.textContent = "Cell";
+      const cellRun = document.createElement("span");
+      cellRun.style.fontSize = "9.5pt";
+      cellRun.textContent = "Cell";
+      cellParagraph.append(cellRun);
       article.append(bodyParagraph, table);
       page.append(article);
       wrapper.append(page);
@@ -1543,7 +1569,9 @@ describe("officePlugin", () => {
       "word/document.xml",
       `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>
         <w:p><w:pPr><w:spacing w:line="300" w:lineRule="auto"/></w:pPr><w:r><w:t>Body</w:t></w:r></w:p>
-        <w:tbl><w:tr><w:tc><w:p><w:pPr><w:spacing w:line="300" w:lineRule="auto"/></w:pPr><w:r><w:t>Cell</w:t></w:r></w:p></w:tc></w:tr></w:tbl>
+        <w:tbl><w:tr><w:tc><w:p><w:pPr><w:spacing w:line="300" w:lineRule="auto"/></w:pPr>
+          <w:r><w:rPr><w:sz w:val="19"/></w:rPr><w:t>Cell</w:t></w:r>
+        </w:p></w:tc></w:tr></w:tbl>
       </w:body></w:document>`
     );
     const container = document.createElement("div");
@@ -1561,7 +1589,63 @@ describe("officePlugin", () => {
     await waitFor(() => container.querySelectorAll("[data-ofv-docx-auto-line-height='true']").length === 2);
 
     expect(container.querySelector<HTMLParagraphElement>("article > p")?.style.lineHeight).toBe("1.6375");
-    expect(container.querySelector<HTMLParagraphElement>("td > p")?.style.lineHeight).toBe("2");
+    expect(container.querySelector<HTMLParagraphElement>("td > p")?.style.lineHeight).toBe("25.3333px");
+    expect(container.querySelector<HTMLParagraphElement>("td > p")?.style.marginTop).toBe("0px");
+  });
+
+  it("removes vertical-merge placeholder paragraphs and restores diagonal DOCX cell borders", async () => {
+    renderDocxAsync.mockImplementationOnce(async (_data: unknown, bodyContainer: HTMLElement) => {
+      const wrapper = document.createElement("div");
+      wrapper.className = "ofv-docx-wrapper";
+      const page = document.createElement("section");
+      page.className = "ofv-docx";
+      const article = document.createElement("article");
+      const table = document.createElement("table");
+      const firstRow = table.insertRow();
+      const mergedCell = firstRow.insertCell();
+      mergedCell.rowSpan = 3;
+      const label = document.createElement("p");
+      label.textContent = "部门";
+      mergedCell.append(label, document.createElement("p"), document.createElement("p"));
+      firstRow.insertCell().textContent = "第一行";
+      table.insertRow().insertCell().textContent = "第二行";
+      table.insertRow().insertCell().textContent = "第三行";
+      article.append(table);
+      page.append(article);
+      wrapper.append(page);
+      bodyContainer.append(wrapper);
+    });
+    const zip = new JSZip();
+    zip.file(
+      "word/document.xml",
+      `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body><w:tbl>
+        <w:tr>
+          <w:tc><w:tcPr><w:vMerge w:val="restart"/><w:tcBorders><w:tl2br w:val="single" w:sz="8" w:color="FF0000"/></w:tcBorders></w:tcPr><w:p><w:r><w:t>部门</w:t></w:r></w:p></w:tc>
+          <w:tc><w:p><w:r><w:t>第一行</w:t></w:r></w:p></w:tc>
+        </w:tr>
+        <w:tr><w:tc><w:tcPr><w:vMerge/></w:tcPr><w:p/></w:tc><w:tc><w:p><w:r><w:t>第二行</w:t></w:r></w:p></w:tc></w:tr>
+        <w:tr><w:tc><w:tcPr><w:vMerge/></w:tcPr><w:p/></w:tc><w:tc><w:p><w:r><w:t>第三行</w:t></w:r></w:p></w:tc></w:tr>
+      </w:tbl></w:body></w:document>`
+    );
+    const container = document.createElement("div");
+    document.body.append(container);
+    createViewer({
+      container,
+      file: await zip.generateAsync({
+        type: "blob",
+        mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+      }),
+      fileName: "merged-diagonal-table.docx",
+      plugins: [officePlugin()]
+    });
+
+    await waitFor(() => Boolean(container.querySelector("[data-ofv-docx-merged-empty-paragraphs-removed='2']")));
+
+    const mergedCell = container.querySelector<HTMLTableCellElement>("td[rowspan='3']");
+    expect(mergedCell?.querySelectorAll(":scope > p")).toHaveLength(1);
+    expect(mergedCell?.dataset.ofvDocxDiagonalTl2br).toBe("true");
+    expect(mergedCell?.style.getPropertyValue("--ofv-docx-diagonal-color")).toBe("#FF0000");
+    expect(mergedCell?.style.getPropertyValue("--ofv-docx-diagonal-half-width")).toBe("0.5pt");
   });
 
   it("aligns right-tab DOCX text to the OOXML tab position", async () => {
@@ -1863,7 +1947,7 @@ describe("officePlugin", () => {
     expect(pages.map((page) => page.querySelector("footer")?.textContent)).toEqual(["-2-", "-3-", "-4-"]);
   });
 
-  it("removes an empty continuation page after restoring the closing date to the cover", async () => {
+  it("removes an empty generated continuation with a section break after restoring the closing date", async () => {
     renderDocxAsync.mockImplementationOnce(async (_data: unknown, bodyContainer: HTMLElement) => {
       const wrapper = document.createElement("div");
       wrapper.className = "ofv-docx-wrapper";
@@ -1881,7 +1965,7 @@ describe("officePlugin", () => {
       emptyContinuation.style.width = "595.3pt";
       emptyContinuation.style.height = "800pt";
       emptyContinuation.style.padding = "36pt";
-      emptyContinuation.innerHTML = `<article><p>2 0 2 5 年 7 月 7 日</p></article><footer><p>—1—</p></footer>`;
+      emptyContinuation.innerHTML = `<article><p>2 0 2 5 年 7 月 7 日</p><p data-ofv-docx-section-break="true"></p></article><footer><p>—1—</p></footer>`;
 
       const bodyPage = document.createElement("section");
       bodyPage.className = "ofv-docx";
@@ -3481,8 +3565,8 @@ describe("officePlugin", () => {
     expect(pages[0].querySelector(".ofv-msdoc-subtitle")?.textContent).toBe("整改的通知");
     expect(pages[1].textContent).toContain("3.接口改造应用清单");
     expect(pages[2].textContent?.trim()).toBe("");
-    expect(pages[3].querySelectorAll(".ofv-msdoc-notice-table tr")).toHaveLength(19);
-    expect(pages[4].querySelectorAll(".ofv-msdoc-notice-table tr")).toHaveLength(3);
+    expect(pages[3].querySelectorAll(".ofv-msdoc-notice-table tr")).toHaveLength(20);
+    expect(pages[4].querySelectorAll(".ofv-msdoc-notice-table tr")).toHaveLength(2);
     expect(pages[5].querySelectorAll(".ofv-msdoc-notice-table tr")).toHaveLength(16);
     expect(pages[6].querySelectorAll(".ofv-msdoc-notice-table tr")).toHaveLength(1);
     expect(pages[4].querySelector(".ofv-msdoc-notice-table th")).toBeNull();
@@ -3774,6 +3858,22 @@ async function createDocxWithSection(pageMargins = ""): Promise<Blob> {
           <w:sectPr><w:pgSz w:w="11906" w:h="16838"/>${pageMargins}</w:sectPr>
         </w:body>
       </w:document>`
+  );
+  return zip.generateAsync({
+    type: "blob",
+    mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+  });
+}
+
+async function createDocxWithAuthoredPageSections(): Promise<Blob> {
+  const zip = new JSZip();
+  zip.file(
+    "word/document.xml",
+    `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>
+      <w:p><w:r><w:t>Page 1</w:t></w:r></w:p>
+      <w:p><w:pPr><w:sectPr/></w:pPr><w:r><w:t>Tail 1</w:t></w:r></w:p>
+      <w:p><w:r><w:t>Page 2</w:t></w:r></w:p><w:p><w:r><w:t>Tail 2</w:t></w:r></w:p><w:sectPr/>
+    </w:body></w:document>`
   );
   return zip.generateAsync({
     type: "blob",

--- a/packages/core/src/plugins/office.ts
+++ b/packages/core/src/plugins/office.ts
@@ -1432,11 +1432,13 @@ async function normalizeDocxLayout(container: HTMLElement, arrayBuffer: ArrayBuf
   repairDocxDefaultPageMargins(container, hints.needsDefaultPageMargins);
   repairDocxSvgImageAlternatives(container, svgImageAlternatives);
   repairUnexpectedDocxTableTextDirections(container, hints.hasVerticalTextDirection);
+  repairDocxDiagonalCellBorders(container, hints.diagonalCellBorders);
   repairDocxFloatingShapeTextboxes(container, hints.floatingShapes);
   repairDocxChartPlaceholders(container, charts);
   repairDocxComplexScriptFontSizes(container, hints.complexScriptFontSizeParagraphs);
   repairDocxCharacterSpacing(container, hints.characterSpacingParagraphs);
   repairDocxAutoLineHeights(container, hints.autoLineHeightParagraphs);
+  repairDocxMergedCellEmptyParagraphs(container, hints.mergedCellEmptyParagraphs);
   markDocxSectionBreakParagraphs(container, hints.sectionBreakParagraphIndexes);
   repairDocxCharacterScaling(container, hints.characterScaleParagraphs);
   const pages = container.querySelectorAll<HTMLElement>("section.ofv-docx");
@@ -1751,6 +1753,20 @@ type DocxLayoutHints = {
     lineMultiple: number;
     fontSizePt?: number;
   }>;
+  diagonalCellBorders: Array<{
+    tableIndex: number;
+    rowIndex: number;
+    columnIndex: number;
+    direction: "tl2br" | "tr2bl";
+    color: string;
+    widthPt: number;
+  }>;
+  mergedCellEmptyParagraphs: Array<{
+    tableIndex: number;
+    rowIndex: number;
+    columnIndex: number;
+    count: number;
+  }>;
   sectionBreakParagraphIndexes: number[];
   needsDefaultPageMargins: boolean;
   hasVerticalTextDirection: boolean;
@@ -1784,6 +1800,8 @@ async function readDocxLayoutHints(arrayBuffer: ArrayBuffer): Promise<DocxLayout
       characterScaleParagraphs: documentXml ? extractDocxCharacterScaleHints(documentXml) : [],
       characterSpacingParagraphs: documentXml ? extractDocxCharacterSpacingHints(documentXml) : [],
       autoLineHeightParagraphs: documentXml ? extractDocxAutoLineHeightHints(documentXml) : [],
+      diagonalCellBorders: documentXml ? extractDocxDiagonalCellBorders(documentXml) : [],
+      mergedCellEmptyParagraphs: documentXml ? extractDocxMergedCellEmptyParagraphs(documentXml) : [],
       sectionBreakParagraphIndexes: documentXml ? extractDocxSectionBreakParagraphIndexes(documentXml) : [],
       needsDefaultPageMargins: Boolean(documentXml && /<w:sectPr\b/.test(documentXml) && !/<w:pgMar\b/.test(documentXml)),
       hasVerticalTextDirection: Boolean(documentXml && /<w:textDirection\b/.test(documentXml))
@@ -1799,6 +1817,8 @@ async function readDocxLayoutHints(arrayBuffer: ArrayBuffer): Promise<DocxLayout
       characterScaleParagraphs: [],
       characterSpacingParagraphs: [],
       autoLineHeightParagraphs: [],
+      diagonalCellBorders: [],
+      mergedCellEmptyParagraphs: [],
       sectionBreakParagraphIndexes: [],
       needsDefaultPageMargins: false,
       hasVerticalTextDirection: false
@@ -2217,15 +2237,188 @@ function repairDocxAutoLineHeights(
     // OOXML's auto value is measured in 240ths of Word's font line box,
     // while a CSS unitless line-height is measured directly against 1em.
     // Word also gives table-cell paragraphs a taller line box than body text.
-    const singleLineEm = paragraph.closest("td, th")
-      ? DOCX_WORD_TABLE_SINGLE_LINE_EM
-      : DOCX_WORD_SINGLE_LINE_EM;
-    paragraph.style.lineHeight = formatCssNumber(hint.lineMultiple * singleLineEm);
+    const tableCell = paragraph.closest("td, th");
+    const singleLineEm = tableCell ? DOCX_WORD_TABLE_SINGLE_LINE_EM : DOCX_WORD_SINGLE_LINE_EM;
+    if (tableCell) {
+      const renderedFontSizePx =
+        getDocxRenderedTextFontSizeInPixels(paragraph) ||
+        (hint.fontSizePt ? hint.fontSizePt * (4 / 3) : getLargestDocxFontSize(paragraph));
+      paragraph.style.lineHeight = `${formatCssNumber(hint.lineMultiple * singleLineEm * renderedFontSizePx)}px`;
+      paragraph.style.marginTop = "0px";
+    } else {
+      paragraph.style.lineHeight = formatCssNumber(hint.lineMultiple * singleLineEm);
+    }
     if (!hint.text && hint.fontSizePt) {
       paragraph.style.fontSize = `${formatCssNumber(hint.fontSizePt)}pt`;
       paragraph.style.minHeight = `${formatCssNumber(hint.fontSizePt * hint.lineMultiple * singleLineEm)}pt`;
     }
     paragraph.dataset.ofvDocxAutoLineHeight = "true";
+  }
+}
+
+function getDocxRenderedTextFontSizeInPixels(paragraph: HTMLParagraphElement): number {
+  const view = paragraph.ownerDocument.defaultView;
+  let largest = 0;
+  for (const run of paragraph.querySelectorAll<HTMLElement>("span")) {
+    if (!normalizePreviewText(run.textContent || "")) {
+      continue;
+    }
+    const inlineSize = parseCssLengthInPixels(run.style.fontSize);
+    const computedSize = view ? parseCssLengthInPixels(view.getComputedStyle(run).fontSize) : 0;
+    largest = Math.max(largest, inlineSize || computedSize);
+  }
+  return largest;
+}
+
+type DocxSourceTableCell = {
+  tableIndex: number;
+  rowIndex: number;
+  columnIndex: number;
+  cell: Element;
+  properties?: Element;
+};
+
+function forEachDocxSourceTableCell(xml: string, visit: (source: DocxSourceTableCell) => void): void {
+  const document = parseOfficeXml(xml);
+  if (!document) {
+    return;
+  }
+  const tables = Array.from(document.getElementsByTagName("*")).filter((element) => element.localName === "tbl");
+  tables.forEach((table, tableIndex) => {
+    const rows = Array.from(table.children).filter((element) => element.localName === "tr");
+    rows.forEach((row, rowIndex) => {
+      const rowProperties = firstDirectOfficeChild(row, "trPr");
+      const gridBefore = rowProperties ? firstDirectOfficeChild(rowProperties, "gridBefore") : undefined;
+      const parsedGridBefore = Number(gridBefore ? getXmlAttribute(gridBefore, "val") : 0);
+      let columnIndex = Number.isFinite(parsedGridBefore) && parsedGridBefore > 0 ? parsedGridBefore : 0;
+      for (const cell of Array.from(row.children).filter((element) => element.localName === "tc")) {
+        const properties = firstDirectOfficeChild(cell, "tcPr");
+        visit({ tableIndex, rowIndex, columnIndex, cell, properties });
+        const gridSpan = properties ? firstDirectOfficeChild(properties, "gridSpan") : undefined;
+        const parsedGridSpan = Number(gridSpan ? getXmlAttribute(gridSpan, "val") : 1);
+        columnIndex += Number.isFinite(parsedGridSpan) && parsedGridSpan > 0 ? parsedGridSpan : 1;
+      }
+    });
+  });
+}
+
+function extractDocxDiagonalCellBorders(xml: string): DocxLayoutHints["diagonalCellBorders"] {
+  const hints: DocxLayoutHints["diagonalCellBorders"] = [];
+  forEachDocxSourceTableCell(xml, ({ tableIndex, rowIndex, columnIndex, properties }) => {
+    const borders = properties ? firstDirectOfficeChild(properties, "tcBorders") : undefined;
+    if (!borders) {
+      return;
+    }
+    for (const direction of ["tl2br", "tr2bl"] as const) {
+      const border = firstDirectOfficeChild(borders, direction);
+      const value = border ? (getXmlAttribute(border, "val") || "single").toLowerCase() : "none";
+      if (!border || value === "none" || value === "nil") {
+        continue;
+      }
+      const rawColor = (getXmlAttribute(border, "color") || "000000").replace(/^#/, "");
+      const widthEighthPoints = Number(getXmlAttribute(border, "sz"));
+      hints.push({
+        tableIndex,
+        rowIndex,
+        columnIndex,
+        direction,
+        color: /^[0-9a-f]{6}$/i.test(rawColor) ? `#${rawColor}` : "#000000",
+        widthPt: Number.isFinite(widthEighthPoints) && widthEighthPoints > 0
+          ? Math.max(0.5, Math.min(6, widthEighthPoints / 8))
+          : 0.75
+      });
+    }
+  });
+  return hints;
+}
+
+function extractDocxMergedCellEmptyParagraphs(xml: string): DocxLayoutHints["mergedCellEmptyParagraphs"] {
+  const hints: DocxLayoutHints["mergedCellEmptyParagraphs"] = [];
+  forEachDocxSourceTableCell(xml, ({ tableIndex, rowIndex, columnIndex, cell, properties }) => {
+    const verticalMerge = properties ? firstDirectOfficeChild(properties, "vMerge") : undefined;
+    if (!verticalMerge || (getXmlAttribute(verticalMerge, "val") || "continue").toLowerCase() === "restart") {
+      return;
+    }
+    const emptyParagraphs = Array.from(cell.children)
+      .filter((element) => element.localName === "p")
+      .filter((paragraph) => {
+        if (normalizePreviewText(paragraph.textContent || "")) {
+          return false;
+        }
+        return !Array.from(paragraph.getElementsByTagName("*")).some((element) =>
+          ["br", "tab", "drawing", "pict", "object"].includes(element.localName)
+        );
+      }).length;
+    if (emptyParagraphs > 0) {
+      hints.push({ tableIndex, rowIndex, columnIndex, count: emptyParagraphs });
+    }
+  });
+  return hints;
+}
+
+function findRenderedDocxTableCell(
+  table: HTMLTableElement,
+  rowIndex: number,
+  columnIndex: number
+): HTMLTableCellElement | undefined {
+  return Array.from(mapDocxTableCellPlacements(Array.from(table.rows)).values())
+    .find((placement) =>
+      placement.columnIndex === columnIndex &&
+      placement.rowIndex <= rowIndex &&
+      placement.rowIndex + placement.rowSpan > rowIndex
+    )?.cell;
+}
+
+function repairDocxDiagonalCellBorders(
+  container: HTMLElement,
+  hints: DocxLayoutHints["diagonalCellBorders"]
+): void {
+  const tables = Array.from(container.querySelectorAll<HTMLTableElement>("section.ofv-docx article table"));
+  for (const hint of hints) {
+    const cell = tables[hint.tableIndex]
+      ? findRenderedDocxTableCell(tables[hint.tableIndex]!, hint.rowIndex, hint.columnIndex)
+      : undefined;
+    if (!cell) {
+      continue;
+    }
+    if (hint.direction === "tl2br") {
+      cell.dataset.ofvDocxDiagonalTl2br = "true";
+    } else {
+      cell.dataset.ofvDocxDiagonalTr2bl = "true";
+    }
+    cell.style.setProperty("--ofv-docx-diagonal-color", hint.color);
+    cell.style.setProperty("--ofv-docx-diagonal-half-width", `${formatCssNumber(hint.widthPt / 2)}pt`);
+  }
+}
+
+function repairDocxMergedCellEmptyParagraphs(
+  container: HTMLElement,
+  hints: DocxLayoutHints["mergedCellEmptyParagraphs"]
+): void {
+  const tables = Array.from(container.querySelectorAll<HTMLTableElement>("section.ofv-docx article table"));
+  const mergedCells = new Set<HTMLTableCellElement>();
+  for (const hint of hints) {
+    const cell = tables[hint.tableIndex]
+      ? findRenderedDocxTableCell(tables[hint.tableIndex]!, hint.rowIndex, hint.columnIndex)
+      : undefined;
+    if (cell && cell.rowSpan > 1) {
+      mergedCells.add(cell);
+    }
+  }
+  for (const cell of mergedCells) {
+    const paragraphs = Array.from(cell.children).filter(
+      (element): element is HTMLParagraphElement => element instanceof HTMLParagraphElement
+    );
+    const removable = paragraphs
+      .filter((paragraph) =>
+        !normalizePreviewText(paragraph.textContent || "") &&
+        !paragraph.querySelector("br, hr, img, svg, canvas, video, audio, object, table")
+      )
+      .reverse();
+    removable.forEach((paragraph) => paragraph.remove());
+    if (removable.length > 0) {
+      cell.dataset.ofvDocxMergedEmptyParagraphsRemoved = String(removable.length);
+    }
   }
 }
 
@@ -2914,6 +3107,13 @@ function paginateDocxFlow(container: HTMLElement): void {
   }
 
   const sourcePages = Array.from(wrapper.querySelectorAll<HTMLElement>(":scope > section.ofv-docx"));
+  const hasAuthoredPageSections =
+    sourcePages.length > 1 &&
+    sourcePages.slice(0, -1).every((page) => page.querySelector("[data-ofv-docx-section-break='true']"));
+  if (hasAuthoredPageSections) {
+    updateDocxContinuationPageNumbers(wrapper);
+    return;
+  }
   for (const sourcePage of sourcePages) {
     paginateDocxPage(sourcePage);
   }
@@ -3044,7 +3244,10 @@ function repairDocxFirstPageClosingDate(container: HTMLElement): void {
     return;
   }
   const sourcePage = dateParagraph.closest<HTMLElement>("section.ofv-docx");
-  if (sourcePage?.querySelector("[data-ofv-docx-section-break='true']")) {
+  if (
+    sourcePage?.querySelector("[data-ofv-docx-section-break='true']") &&
+    sourcePage.dataset.ofvDocxFlowContinuation !== "true"
+  ) {
     return;
   }
   const signatory = Array.from(firstPage.querySelectorAll<HTMLElement>("article p"))

--- a/packages/core/src/style.css
+++ b/packages/core/src/style.css
@@ -1965,6 +1965,38 @@
   overflow-wrap: anywhere;
 }
 
+.ofv-docx-document section.ofv-docx :is(td, th)[data-ofv-docx-diagonal-tl2br="true"],
+.ofv-docx-document section.ofv-docx :is(td, th)[data-ofv-docx-diagonal-tr2bl="true"] {
+  position: relative;
+}
+
+.ofv-docx-document section.ofv-docx :is(td, th)[data-ofv-docx-diagonal-tl2br="true"]::after,
+.ofv-docx-document section.ofv-docx :is(td, th)[data-ofv-docx-diagonal-tr2bl="true"]::before {
+  position: absolute;
+  z-index: 1;
+  inset: 0;
+  pointer-events: none;
+  content: "";
+}
+
+.ofv-docx-document section.ofv-docx :is(td, th)[data-ofv-docx-diagonal-tl2br="true"]::after {
+  background: linear-gradient(
+    to top right,
+    transparent calc(50% - var(--ofv-docx-diagonal-half-width, 0.375pt)),
+    var(--ofv-docx-diagonal-color, #000) 50%,
+    transparent calc(50% + var(--ofv-docx-diagonal-half-width, 0.375pt))
+  );
+}
+
+.ofv-docx-document section.ofv-docx :is(td, th)[data-ofv-docx-diagonal-tr2bl="true"]::before {
+  background: linear-gradient(
+    to top left,
+    transparent calc(50% - var(--ofv-docx-diagonal-half-width, 0.375pt)),
+    var(--ofv-docx-diagonal-color, #000) 50%,
+    transparent calc(50% + var(--ofv-docx-diagonal-half-width, 0.375pt))
+  );
+}
+
 .ofv-docx-right-tab-line {
   display: flex;
   align-items: baseline;


### PR DESCRIPTION
## 变更说明

- 按真实文字字号还原 DOCX 表格自动行距，移除纵向合并单元格累积的空段落。
- 恢复 `tl2br` / `tr2bl` 对角线表头，并保持原始线宽和颜色。
- 尊重作者设置的分节分页，避免文档被二次分页；签章页日期可从空续页移回首页。
- 调整旧版 `.doc` 六列表格分页容量，使第 17-19 行保留在前页、第 20-21 行进入续页。

## 关联 Issue

Fixes #126

## 验证结果

- [x] 已运行与本次变更相关的测试或检查
- [x] 已使用真实文件验证修改后的预览效果
- [x] 本次修改不包含无关变更

- Office 插件测试：105 项全部通过。
- 其余全仓测试：1908 项全部通过；完整测试唯一失败为 `origin/main` 已存在的 Windows esbuild 入口路径兼容问题（`optional-peer-build.test.ts`）。
- 全仓 TypeScript 类型检查通过。
- 4 个 SDK 包、4 个示例、文档站构建及包导出检查通过。
- `git diff --check` 通过。
- 浏览器控制台无错误。
- Issue 真实 DOCX：由 26 页、7 张 HTML 表格修正为 13 页、4 张表；表格行数为 3 / 18 / 21 / 29；第 11 页结束于第 15 行，第 12 页为第 16-36 行，第 13 页完整显示 29 行，表格均未与页脚重叠。
- Issue 真实 DOC：第 17-19 行保留在前页，第 20-21 行进入续页，与 Word 原稿一致；前页表格底部距可用页底约 34px。

## 预览成功截图

- [ ] 截图来自本次变更的实际预览结果

真实文件预览已完成；当前自动化会话没有 GitHub Web 登录态，暂未能通过附件通道上传截图。